### PR TITLE
feat: retention records and handler

### DIFF
--- a/src/deadline/job_attachments/bucket_sweeper/retention_record_handler.py
+++ b/src/deadline/job_attachments/bucket_sweeper/retention_record_handler.py
@@ -1,0 +1,260 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import json
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from ..models import RetentionRecord
+from typing import TypedDict, List, Dict, Tuple
+from ..exceptions import RetentionRecordHandlerError
+
+
+class RetentionRecordHandlerInterface(ABC):
+    @abstractmethod
+    def insert_retention_records(self, records: List[RetentionRecord]) -> None:
+        pass
+
+    @abstractmethod
+    def get_retention_records(
+        self, queue_job_id_map: Dict[str, List[str]]
+    ) -> List[RetentionRecord]:
+        pass
+
+
+"""
+TypedDict classes to define data structure saved to disk.
+
+Example:
+    "queues": {
+            "queue-1": {
+                "jobs": {
+                    "job-1": ["key1", "key2"]
+                    "job-2": ["key3", "key4"]
+                }
+            }
+    }
+"""
+
+
+class JobKeyMapping(TypedDict):
+    """Maps JobId to a list of S3 Keys"""
+
+    jobs: Dict[str, List[str]]
+
+
+class QueueJobKeyMapping(TypedDict):
+    """Maps QueueId to a dictionary where keys are JobIds"""
+
+    queues: Dict[str, JobKeyMapping]
+
+
+class RetentionRecordHandler(RetentionRecordHandlerInterface):
+    def __init__(self, storage_file_path: Path):
+        """
+        Initialize a retention record handler.
+
+        Creates a new handler instance that manages retention records in the specified directory.
+        The handler will create or use a 'retention_records.json' file in this directory
+        for persistent storage.
+
+        Args:
+            storage_file_path: Path to the storage file. The file must be a JSON file and the
+            directory must be writable.
+
+        Note:
+            This will automatically initialize the storage file if it doesn't exist
+            through the _initialize_storage method.
+        """
+        self.storage_file_path: Path = storage_file_path
+        self._initialize_storage()
+
+    def _initialize_storage(self):
+        """
+        Initializes the retention records storage file if it doesn't exist. If the file already
+        exists, the function will throw an error.
+
+        Creates the storage file with an empty JSON object.
+
+        Raises:
+            RetentionRecordHandlerError: If storage file already exists or it cannot be created
+                (e.g., due to permissions, disk space, or invalid path).
+        """
+        if self.storage_file_path.exists():
+            raise RetentionRecordHandlerError(
+                "Failed to initialize handler, storage file already exists"
+            )
+
+        try:
+            content: QueueJobKeyMapping = {"queues": {}}
+            self.storage_file_path.write_text(json.dumps(content))
+        except Exception as err:
+            raise RetentionRecordHandlerError(
+                f"Failed to create retention record storage file: {str(err)}"
+            )
+
+    def insert_retention_records(self, records: List[RetentionRecord]) -> None:
+        """
+        Insert retention records into the storage system, avoiding duplicates.
+
+        This method takes a list of retention records and merges them with existing records.
+        If a record with the same queue_id, job_id, and s3_object_key already exists, it will not be duplicated.
+
+        Note:
+            See top of the file for an example of the QueueJobKeyMapping data structure being saved to disk.
+
+        Args:
+            records (List[RetentionRecord]): A list of RetentionRecord objects to be inserted.
+                Each RetentionRecord should contain queue_id, job_id, and s3_object_key attributes.
+
+        Raises:
+            RetentionRecordHandlerError: if loading or writing records fail
+        """
+        existing_records: QueueJobKeyMapping = self._load_existing_records_from_file()
+        queues: Dict[str, JobKeyMapping] = existing_records["queues"]
+
+        for record in records:
+            if record.queue_id not in queues:
+                queues[record.queue_id] = JobKeyMapping(jobs={})
+
+            queue_jobs: Dict[str, List[str]] = queues[record.queue_id]["jobs"]
+
+            if record.job_id not in queue_jobs:
+                queue_jobs[record.job_id] = []
+
+            job_keys: List[str] = queue_jobs[record.job_id]
+
+            # Avoid duplicate keys for the same job
+            if record.s3_object_key not in job_keys:
+                job_keys.append(record.s3_object_key)
+
+        self._write_records_to_file(existing_records)
+
+    def get_retention_records(
+        self, queue_job_id_map: Dict[str, List[str]]
+    ) -> List[RetentionRecord]:
+        """
+        Retrieve retention records based on a mapping of queue IDs to job IDs. Deletes duplicate job IDs
+        in queue_job_id_map before retrieving records.
+
+        Args:
+            queue_job_id_map (Dict[str, List[str]]): A dictionary mapping queue IDs to lists of job IDs.
+                Example: {'queue1': ['job1', 'job2'], 'queue2': ['job3']}
+
+        Returns:
+            List[RetentionRecord]: A list of RetentionRecord objects matching the specified criteria.
+                Returns an empty list if no matching records are found.
+
+        Raises:
+            RetentionRecordHandlerError: if loading records fails
+
+        Note:
+            Non-existent queue IDs or job IDs are silently skipped during the filtering process.
+        """
+        sanitized_query_job_map = self._prune_and_deduplicate_query_map(
+            queue_job_id_map=queue_job_id_map
+        )
+        existing_records: QueueJobKeyMapping = self._load_existing_records_from_file()
+
+        selected_records: List[RetentionRecord] = []
+
+        # Flatten query map
+        all_queue_job_pairs: List[Tuple[str, str]] = []
+        for queue, jobs in sanitized_query_job_map.items():
+            all_queue_job_pairs.extend((queue, job) for job in jobs)
+
+        queues: Dict[str, JobKeyMapping] = existing_records["queues"]
+        for queue_id, job_id in all_queue_job_pairs:
+            # Skip if queue_id or job_id is not present in the dictionary
+            if queue_id not in queues or job_id not in queues[queue_id]["jobs"]:
+                continue
+
+            job_s3_keys: List[str] = queues[queue_id]["jobs"][job_id]
+
+            selected_records.extend(
+                RetentionRecord(queue_id, job_id, s3_key) for s3_key in job_s3_keys
+            )
+
+        return selected_records
+
+    def _prune_and_deduplicate_query_map(
+        self, queue_job_id_map: Dict[str, List[str]]
+    ) -> Dict[str, List[str]]:
+        """
+        Sanitize and deduplicate the queue-to-job ID mapping.
+
+        Processes the input mapping by:
+        1. Removing queue IDs with empty job lists
+        2. Deduplicating job IDs within each queue
+
+        Args:
+            queue_job_id_map (Dict[str, List[str]]): Mapping of queue IDs to lists of job IDs,
+                potentially containing duplicates or empty lists.
+                Example: {'queue1': ['job1', 'job2'], 'queue2': ['job3']}
+
+        Returns:
+            Dict[str, List[str]]: Sanitized mapping where:
+                - Values are deduplicated lists of job IDs
+                - Queues with empty job lists are excluded
+        """
+        sanitized_map: Dict[str, List[str]] = {}
+
+        for queue_id, job_ids in queue_job_id_map.items():
+            if not job_ids:
+                continue
+            unique_jobs = set(job_ids)
+            sanitized_map[queue_id] = list(unique_jobs)
+
+        return sanitized_map
+
+    def _load_existing_records_from_file(self) -> QueueJobKeyMapping:
+        """
+        Reads and parses the JSON storage file containing retention records.
+
+        Note:
+            See top of the file for an example of the QueueJobKeyMapping data structure.
+
+        Returns:
+            QueueJobKeyMapping: Nested dictionary mapping queueIds <-> JobIds <-> S3 keys
+
+        Raises:
+            RetentionRecordHandlerError: If the file cannot be read or parsed.
+        """
+        try:
+            file_data = self.storage_file_path.read_text(encoding="utf-8")
+            existing_records: QueueJobKeyMapping = json.loads(file_data)
+        except Exception as err:
+            raise RetentionRecordHandlerError(f"Failed to read storage file: {str(err)}")
+
+        return existing_records
+
+    def _write_records_to_file(self, records: QueueJobKeyMapping) -> None:
+        """
+        Serializes and saves the records dictionary to JSON format.
+
+        Note:
+            See top of the file for an example of the QueueJobKeyMapping data structure.
+
+        Args:
+            records: QueueJobKeyMapping
+
+        Raises:
+            RetentionRecordHandlerError: If the file cannot be written to or if JSON serialization fails.
+        """
+        try:
+            self.storage_file_path.write_text(json.dumps(records), encoding="utf-8")
+        except Exception as err:
+            raise RetentionRecordHandlerError(f"Failed to write to storage file: {str(err)}")
+
+    def delete_storage(self) -> None:
+        """
+        Removes the storage file from the filesystem if it exists.
+
+        If the file doesn't exist, the operation is skipped silently.
+
+        Raises:
+            RetentionRecordHandlerError: If the file exists but cannot be deleted
+        """
+        try:
+            self.storage_file_path.unlink(missing_ok=True)
+        except Exception as err:
+            raise RetentionRecordHandlerError(f"Failed to delete storage file: {str(err)}")

--- a/src/deadline/job_attachments/exceptions.py
+++ b/src/deadline/job_attachments/exceptions.py
@@ -199,3 +199,11 @@ class JobAttachmentsSweeperError(BucketSweeperError):
     """
     Exception for manifest processing in bucket sweeper.
     """
+
+
+class RetentionRecordHandlerError(Exception):
+    """Error for retention record handler operations"""
+
+    def __init__(self, message):
+        self.message = message
+        super().__init__(message)

--- a/src/deadline/job_attachments/manifest_handling.py
+++ b/src/deadline/job_attachments/manifest_handling.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 import boto3
-import os
 
 from botocore.client import BaseClient
 from botocore.exceptions import ClientError

--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -503,3 +503,12 @@ class AssetHash:
 
     hash: str
     hash_alg: HashAlgorithm
+
+
+@dataclass
+class RetentionRecord:
+    """Data structure to store retention records"""
+
+    queue_id: str
+    job_id: str
+    s3_object_key: str

--- a/test/unit/deadline_job_attachments/bucket_sweeper/test_retention_record_handler.py
+++ b/test/unit/deadline_job_attachments/bucket_sweeper/test_retention_record_handler.py
@@ -1,0 +1,356 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import pytest
+import json
+from unittest.mock import patch
+from pathlib import Path
+from typing import Dict, List
+
+from deadline.job_attachments.exceptions import RetentionRecordHandlerError
+from deadline.job_attachments.bucket_sweeper.retention_record_handler import (
+    QueueJobKeyMapping,
+    RetentionRecordHandler,
+)
+from deadline.job_attachments.models import RetentionRecord
+
+
+@pytest.fixture
+def handler(tmp_path: Path) -> RetentionRecordHandler:
+    sotrage_file_path: Path = tmp_path / "retention_records.json"
+    return RetentionRecordHandler(storage_file_path=sotrage_file_path)
+
+
+class TestRetentionRecordHandler:
+    def test_initialize_storage_happy_path(self, tmp_path: Path):
+        """Test successful initialization when storage file doesn't exist"""
+
+        # Constructor initializes storage file automatically
+        storage_file_path: Path = tmp_path / "retention_records.json"
+        handler = RetentionRecordHandler(storage_file_path=storage_file_path)
+
+        assert handler.storage_file_path.exists()
+        with open(handler.storage_file_path, "r") as file:
+            assert json.load(file) == {"queues": {}}
+
+    def test_initialize_storage_file_exists(self, handler: RetentionRecordHandler):
+        """Test initialization fails when storage file already exists"""
+
+        storage_file: Path = Path(handler.storage_file_path)
+        storage_file.touch()
+
+        with pytest.raises(RetentionRecordHandlerError) as err:
+            handler._initialize_storage()
+
+        assert "storage file already exists" in str(err)
+
+    def test_initialize_storage_write_fails(self, tmp_path: Path):
+        """Test initialization fails when writing to file fails"""
+
+        storage_file_path: Path = tmp_path / "retention_records.json"
+        handler: RetentionRecordHandler = RetentionRecordHandler(
+            storage_file_path=storage_file_path
+        )
+
+        # Mock Path.exists to return False
+        with patch.object(Path, "exists", return_value=False):
+            # Mock Path.write_text to raise an IOError
+            with patch.object(Path, "write_text", side_effect=IOError("Permission denied")):
+                with pytest.raises(RetentionRecordHandlerError) as err:
+                    handler._initialize_storage()
+
+                assert "Failed to create retention record storage file" in str(err.value)
+                assert "Permission denied" in str(err.value)
+
+    def test_load_multiple_records_happy_path(
+        self, handler: RetentionRecordHandler, tmp_path: Path
+    ):
+        """Test loading multiple existing records"""
+        test_data: QueueJobKeyMapping = {
+            "queues": {
+                "queue-1": {"jobs": {"job-1": ["key1", "key2"], "job-2": ["key3"]}},
+                "queue-2": {"jobs": {"job-3": ["key4", "key5", "key6"]}},
+            }
+        }
+
+        file_path: Path = tmp_path / "retention_records.json"
+        file_path.write_text(json.dumps(test_data))
+
+        records: QueueJobKeyMapping = handler._load_existing_records_from_file()
+
+        assert records == test_data
+
+        assert "queues" in records
+        assert "queue-1" in records["queues"]
+        assert "jobs" in records["queues"]["queue-1"]
+        assert "job-1" in records["queues"]["queue-1"]["jobs"]
+
+        assert records["queues"]["queue-1"]["jobs"]["job-1"] == ["key1", "key2"]
+        assert records["queues"]["queue-1"]["jobs"]["job-2"] == ["key3"]
+        assert records["queues"]["queue-2"]["jobs"]["job-3"] == ["key4", "key5", "key6"]
+
+    def test_load_empty_records(self, handler: RetentionRecordHandler, tmp_path: Path):
+        """Test loading when storage file exists but is empty"""
+        records: QueueJobKeyMapping = handler._load_existing_records_from_file()
+
+        assert records == {"queues": {}}
+
+    def test_load_nonexistent_file(self, handler: RetentionRecordHandler, tmp_path: Path):
+        """Test loading from a non-existent file"""
+
+        # Remove the created storage file
+        storage_file: Path = tmp_path / "retention_records.json"
+        storage_file.unlink(missing_ok=True)
+
+        with pytest.raises(RetentionRecordHandlerError) as err:
+            handler._load_existing_records_from_file()
+
+        assert "Failed to read storage file" in str(err.value)
+
+    def test_load_io_error(self, handler: RetentionRecordHandler):
+        """Test handling of IO error while reading file"""
+
+        # Mock Path.read_text to raise an IOError
+        with patch.object(Path, "read_text", side_effect=IOError("Permission denied")):
+            with pytest.raises(RetentionRecordHandlerError) as err:
+                handler._load_existing_records_from_file()
+
+            assert "Failed to read storage file" in str(err.value)
+            assert "Permission denied" in str(err.value)
+
+    def test_write_records_to_file_multiple_records_happy_path(
+        self, handler: RetentionRecordHandler
+    ):
+        """Test writing multiple records successfully"""
+        test_records: QueueJobKeyMapping = {
+            "queues": {
+                "queue-1": {"jobs": {"job-1": ["key1", "key2"], "job-2": ["key3"]}},
+                "queue-2": {"jobs": {"job-3": ["key4", "key5", "key6"]}},
+            }
+        }
+
+        handler._write_records_to_file(test_records)
+
+        saved_records: QueueJobKeyMapping = json.loads(handler.storage_file_path.read_text())
+
+        assert saved_records == test_records
+
+        assert "queues" in saved_records
+        assert "queue-1" in saved_records["queues"]
+        assert "jobs" in saved_records["queues"]["queue-1"]
+
+        assert saved_records["queues"]["queue-1"]["jobs"]["job-1"] == ["key1", "key2"]
+        assert saved_records["queues"]["queue-1"]["jobs"]["job-2"] == ["key3"]
+        assert saved_records["queues"]["queue-2"]["jobs"]["job-3"] == ["key4", "key5", "key6"]
+
+    def test_write_records_to_file_empty_records(self, handler: RetentionRecordHandler):
+        """Test writing an empty records dictionary"""
+        empty_records: QueueJobKeyMapping = {"queues": {}}
+
+        handler._write_records_to_file(empty_records)
+
+        saved_records: QueueJobKeyMapping = json.loads(handler.storage_file_path.read_text())
+
+        assert saved_records == {"queues": {}}
+
+    def test_write_records_io_error(self, handler: RetentionRecordHandler):
+        """Test handling IO error when attempting to write records to file"""
+
+        # Mock Path.write_text to raise an IOError
+        with patch.object(Path, "write_text", side_effect=IOError("Permission denied")):
+            with pytest.raises(RetentionRecordHandlerError) as err:
+                handler._write_records_to_file({"queues": {}})
+
+            error_message: str = str(err.value)
+            assert "Failed to write to storage file" in error_message
+            assert "Permission denied" in error_message
+
+    def test_prune_and_deduplicate_query_map_multiple_keys(self, handler: RetentionRecordHandler):
+        """Test cleaning a queue_job_id_map with multiple queues, duplicates, and empty lists"""
+        input_map: Dict[str, List[str]] = {
+            "queue-1": ["job-1", "job-2", "job-1", "job-3"],  # Contains duplicates
+            "queue-2": ["job-4", "job-5"],
+            "queue-3": [],  # Empty list, should be removed
+            "queue-4": ["job-6", "job-6", "job-7"],  # Contains duplicates
+        }
+
+        sanitized_map: Dict[str, List[str]] = handler._prune_and_deduplicate_query_map(input_map)
+
+        expected_map: Dict[str, List[str]] = {
+            "queue-1": ["job-1", "job-2", "job-3"],
+            "queue-2": ["job-4", "job-5"],
+            "queue-4": ["job-6", "job-7"],
+        }
+
+        assert sorted(sanitized_map["queue-1"]) == sorted(expected_map["queue-1"])
+        assert sorted(sanitized_map["queue-2"]) == sorted(expected_map["queue-2"])
+        assert sorted(sanitized_map["queue-4"]) == sorted(expected_map["queue-4"])
+        assert "queue-3" not in sanitized_map
+
+    def test_delete_storage_file_exists_happy_path(self, handler: RetentionRecordHandler):
+        """Test deleting an existing storage file"""
+
+        # Storage file is created on initialization
+        handler.delete_storage()
+
+        assert not handler.storage_file_path.exists()
+
+    def test_delete_storage_file_does_not_exist(self, handler: RetentionRecordHandler):
+        """Test attempting to delete a non-existent storage file"""
+        if handler.storage_file_path.exists():
+            handler.storage_file_path.unlink()
+
+        handler.delete_storage()
+
+        assert not handler.storage_file_path.exists()
+
+    def test_delete_storage_io_error(self, handler: RetentionRecordHandler):
+        """Test handling IO error when attempting to delete storage file"""
+        with patch.object(Path, "unlink") as mock_unlink:
+            mock_unlink.side_effect = IOError("Permission denied")
+
+            with pytest.raises(RetentionRecordHandlerError) as err:
+                handler.delete_storage()
+
+            error_message: str = str(err.value)
+            assert "Failed to delete storage file" in error_message
+            assert "Permission denied" in error_message
+
+    def test_insert_retention_records_multiple_records_happy_path(
+        self, handler: RetentionRecordHandler
+    ):
+        """Test inserting multiple new retention records"""
+        records: List[RetentionRecord] = [
+            RetentionRecord("queue-1", "job-1", "key1"),
+            RetentionRecord("queue-1", "job-1", "key2"),
+            RetentionRecord("queue-1", "job-2", "key3"),
+            RetentionRecord("queue-2", "job-3", "key4"),
+        ]
+
+        with patch.object(handler, "_load_existing_records_from_file") as mock_load:
+            with patch.object(handler, "_write_records_to_file") as mock_write:
+                mock_load.return_value = {"queues": {}}
+
+                handler.insert_retention_records(records)
+
+                expected_records: QueueJobKeyMapping = {
+                    "queues": {
+                        "queue-1": {"jobs": {"job-1": ["key1", "key2"], "job-2": ["key3"]}},
+                        "queue-2": {"jobs": {"job-3": ["key4"]}},
+                    }
+                }
+
+                mock_write.assert_called_once_with(expected_records)
+
+    def test_insert_retention_records_empty_list(self, handler: RetentionRecordHandler):
+        """Test inserting an empty list of retention records"""
+        records: List[RetentionRecord] = []
+
+        with patch.object(handler, "_load_existing_records_from_file") as mock_load:
+            with patch.object(handler, "_write_records_to_file") as mock_write:
+                mock_load.return_value = {"queues": {}}
+
+                handler.insert_retention_records(records)
+
+                mock_write.assert_called_once_with({"queues": {}})
+
+    def test_insert_retention_records_with_existing_records(self, handler: RetentionRecordHandler):
+        """Test inserting records when some records already exist"""
+        existing_records: QueueJobKeyMapping = {
+            "queues": {"queue-1": {"jobs": {"job-1": ["key1"], "job-2": ["key2"]}}}
+        }
+
+        new_records: List[RetentionRecord] = [
+            RetentionRecord("queue-1", "job-1", "key1"),  # Duplicate, should not be added
+            RetentionRecord("queue-1", "job-1", "key3"),  # New object for existing job
+            RetentionRecord("queue-2", "job-3", "key4"),  # Completely new record
+        ]
+
+        with patch.object(handler, "_load_existing_records_from_file") as mock_load:
+            with patch.object(handler, "_write_records_to_file") as mock_write:
+                mock_load.return_value = existing_records
+
+                handler.insert_retention_records(new_records)
+
+                expected_records: QueueJobKeyMapping = {
+                    "queues": {
+                        "queue-1": {"jobs": {"job-1": ["key1", "key3"], "job-2": ["key2"]}},
+                        "queue-2": {"jobs": {"job-3": ["key4"]}},
+                    }
+                }
+                mock_write.assert_called_once_with(expected_records)
+
+    def test_get_retention_records_multiple_records_happy_path(
+        self, handler: RetentionRecordHandler
+    ):
+        """Test retrieving multiple records across different queues and jobs"""
+        existing_records: QueueJobKeyMapping = {
+            "queues": {
+                "queue-1": {"jobs": {"job-1": ["key1", "key2"], "job-2": ["key3"]}},
+                "queue-2": {"jobs": {"job-3": ["key4"]}},
+            }
+        }
+
+        queue_job_id_map: Dict[str, List[str]] = {
+            "queue-1": ["job-1", "job-2"],
+            "queue-2": ["job-3"],
+        }
+
+        with patch.object(handler, "_load_existing_records_from_file") as mock_load:
+            with patch.object(handler, "_prune_and_deduplicate_query_map") as mock_clean:
+                mock_load.return_value = existing_records
+                mock_clean.return_value = queue_job_id_map
+
+                records = handler.get_retention_records(queue_job_id_map)
+
+                expected_records = [
+                    RetentionRecord("queue-1", "job-1", "key1"),
+                    RetentionRecord("queue-1", "job-1", "key2"),
+                    RetentionRecord("queue-1", "job-2", "key3"),
+                    RetentionRecord("queue-2", "job-3", "key4"),
+                ]
+                assert records == expected_records
+
+    def test_get_retention_records_empty_map(self, handler: RetentionRecordHandler):
+        """Test retrieving records with empty queue_job_id_map"""
+        existing_records: QueueJobKeyMapping = {
+            "queues": {"queue-1": {"jobs": {"job-1": ["key1"]}}}
+        }
+
+        queue_job_id_map: Dict[str, List[str]] = {}
+
+        with patch.object(handler, "_load_existing_records_from_file") as mock_load:
+            with patch.object(handler, "_prune_and_deduplicate_query_map") as mock_clean:
+                mock_load.return_value = existing_records
+                mock_clean.return_value = queue_job_id_map
+
+                records = handler.get_retention_records(queue_job_id_map)
+
+                assert records == []
+
+    def test_get_retention_records_partial_matches(self, handler: RetentionRecordHandler):
+        """Test retrieving records where some queues/jobs exist and others don't"""
+        existing_records: QueueJobKeyMapping = {
+            "queues": {
+                "queue-1": {"jobs": {"job-1": ["key1"], "job-2": ["key2"]}},
+                "queue-2": {"jobs": {"job-3": ["key3"]}},
+            }
+        }
+
+        queue_job_id_map: Dict[str, List[str]] = {
+            "queue-1": ["job-1", "job-nonexistent"],  # One valid, one invalid job
+            "queue-2": ["job-3"],  # Valid queue and job
+            "queue-nonexistent": ["job-1"],  # Invalid queue
+        }
+
+        with patch.object(handler, "_load_existing_records_from_file") as mock_load:
+            with patch.object(handler, "_prune_and_deduplicate_query_map") as mock_clean:
+                mock_load.return_value = existing_records
+                mock_clean.return_value = queue_job_id_map
+
+                records = handler.get_retention_records(queue_job_id_map)
+
+                expected_records = [
+                    RetentionRecord("queue-1", "job-1", "key1"),
+                    RetentionRecord("queue-2", "job-3", "key3"),
+                ]
+                assert records == expected_records

--- a/test/unit/deadline_job_attachments/test_manifest_handling.py
+++ b/test/unit/deadline_job_attachments/test_manifest_handling.py
@@ -5,7 +5,7 @@ import pytest
 
 from pathlib import Path
 from typing import List
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, patch
 from botocore.exceptions import ClientError
 
 from deadline.job_attachments.manifest_handling import (
@@ -324,7 +324,9 @@ class TestManifestHandling:
         (manifests_dir / "manifest1.json").write_text(manifest_content_1)
         (manifests_dir / "manifest2.json").write_text(manifest_content_2)
 
-        resulting_manifest_list: List[BaseAssetManifest] = _load_manifests_from_disk(manifests_directory=manifests_dir)
+        resulting_manifest_list: List[BaseAssetManifest] = _load_manifests_from_disk(
+            manifests_directory=manifests_dir
+        )
 
         expected_manifest_1: BaseAssetManifest = decode_manifest(manifest_content_1)
         expected_manifest_2: BaseAssetManifest = decode_manifest(manifest_content_2)
@@ -358,7 +360,7 @@ class TestManifestHandling:
         manifest_path = manifest_dir / "manifest.json"
         manifest_path.touch()
 
-        with patch.object(Path, 'read_text', side_effect=IOError("Permission denied")):
+        with patch.object(Path, "read_text", side_effect=IOError("Permission denied")):
             with pytest.raises(JobAttachmentsError) as err:
                 _load_manifests_from_disk(manifest_dir)
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Part of the bucket sweeper project.

This PR implements the model for data saved to disk and a handler class to handle read and write operations for RetentionRecords. A `RetentionRecord` represents an individual asset or manifest that must not be deleted from the job attachments bucket.

In practice, this is how RetentionRecords should be used:
1. Get all manifests (input and output) for a job whose files you'd like to retain.
2. Extract asset hashes from all of these manifests.
3. Create a RetentionRecord for every individual manifest and asset.
4. Use a RetentionRecordHandler to save and load records from disk.

### What was the solution? (How)
1. Create a RetentionRecord data model.
2. Create a Retention Record handler to save records to disk and load records from disk.

### What is the impact of this change?
No impact to Deadline Cloud functionality. All code in this PR does not modify or delete Deadline data.

### How was this change tested?
- Added unit tests
- Ran all unit tests
- Ran integration tests
- Manual E2E tests

### Manual E2E Test
**Test Code**
<img width="781" height="636" alt="Screenshot 2025-07-14 at 11 58 40 AM" src="https://github.com/user-attachments/assets/e0e3941e-385c-4672-b95a-1e2f486fbc9e" />

**Console Output**
<img width="523" height="232" alt="Screenshot 2025-07-14 at 11 58 49 AM" src="https://github.com/user-attachments/assets/a578d0df-26d6-46e4-b5fd-319f41d7ffe3" />

**Storage File Content**
<img width="326" height="446" alt="Screenshot 2025-07-14 at 12 00 18 PM" src="https://github.com/user-attachments/assets/5354981d-d125-4629-b7d7-aa1b1b601ac0" />



See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
<img width="1000" height="105" alt="image" src="https://github.com/user-attachments/assets/69fcd42c-e4c5-42fa-a900-2b32de0a3191" />

- Have you run the integration tests?
<img width="1000" height="104" alt="image" src="https://github.com/user-attachments/assets/14688599-16f1-4b81-a055-05e396a24045" />

- Have you made changes to the `download` or `asset_sync` modules? No
If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.

### Was this change documented?

- Are relevant docstrings in the code base updated?
- Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change? No

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

### Does this change impact security? No

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
