### PR TITLE
feat: add get attachments to retain function

### DIFF
--- a/src/deadline/job_attachments/bucket_sweeper/job_attachments_sweeper.py
+++ b/src/deadline/job_attachments/bucket_sweeper/job_attachments_sweeper.py
@@ -2,11 +2,20 @@
 
 import csv
 
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Set
 from botocore.exceptions import BotoCoreError
 from botocore.client import BaseClient
 
-from ..exceptions import JobAttachmentsSweeperError, JobAttachmentS3BotoCoreError
+from deadline.job_attachments.bucket_sweeper.retention_record_handler import (
+    RetentionRecordHandlerInterface,
+)
+from deadline.job_attachments.models import RetentionRecord
+
+from ..exceptions import (
+    JobAttachmentsSweeperError,
+    JobAttachmentS3BotoCoreError,
+    RetentionRecordHandlerError,
+)
 
 
 class JobAttachmentsSweeper:
@@ -17,6 +26,7 @@ class JobAttachmentsSweeper:
         s3_client: BaseClient,
         s3_control_client: BaseClient,
         deadline_client: BaseClient,
+        retention_record_handler: RetentionRecordHandlerInterface,
         farm_id: str,
         account_id: str,
         role_arn: str,
@@ -41,10 +51,46 @@ class JobAttachmentsSweeper:
         self.s3 = s3_client
         self.s3_control = s3_control_client
         self.deadline = deadline_client
+        self.retention_record_handler = retention_record_handler
         self.farm_id = farm_id
         self.account_id = account_id
         self.role_arn = role_arn
         self.bucket_name = bucket_name
+
+    def get_attachments_to_retain(self, queue_job_id_map: Dict[str, List[str]]) -> Set[str]:
+        """
+        Retrieves a set of S3 object keys that should be retained based on queue and job IDs.
+
+        This method queries the retention record handler to get retention records for the specified
+        queue and job IDs, then extracts the unique S3 object keys from those records. The returned
+        set contains S3 object keys that should be retained during cleanup operations.
+
+        Args:
+            queue_job_id_map: A dictionary mapping queue IDs to lists of job IDs. For each queue ID,
+                            the associated job IDs will be used to find retention records.
+                Example: { "queue-1": ["job-1"], "queue-2": ["job-2"] }
+
+        Returns:
+            Set[str]: A set of unique S3 object keys that should be retained.
+
+        Raises:
+            JobAttachmentsSweeperError: If there's an error retrieving retention records from the
+                                    record handler.
+
+        Note:
+            If the queue_job_id_map is empty or if no retention records are found for the specified
+            queue and job IDs, an empty set will be returned.
+        """
+        try:
+            records: List[RetentionRecord] = self.retention_record_handler.get_retention_records(
+                queue_job_id_map=queue_job_id_map
+            )
+        except RetentionRecordHandlerError as err:
+            raise JobAttachmentsSweeperError(message=f"Failed to get retention records: {str(err)}")
+
+        retain_object_keys: Set[str] = {record.s3_object_key for record in records}
+
+        return retain_object_keys
 
     def _create_tag_manifest(self, file_path: str, delete_list: List[str]) -> None:
         """

--- a/test/unit/deadline_job_attachments/bucket_sweeper/test_job_attachments_sweeper.py
+++ b/test/unit/deadline_job_attachments/bucket_sweeper/test_job_attachments_sweeper.py
@@ -1,16 +1,18 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from botocore.exceptions import BotoCoreError
+from deadline.job_attachments.models import RetentionRecord
 import pytest
 import os
 import csv
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Set
 from pathlib import Path
 from unittest.mock import Mock
 from deadline.job_attachments.bucket_sweeper.job_attachments_sweeper import JobAttachmentsSweeper
 from deadline.job_attachments.exceptions import (
     JobAttachmentsSweeperError,
     JobAttachmentS3BotoCoreError,
+    RetentionRecordHandlerError,
 )
 
 
@@ -33,12 +35,21 @@ def mock_deadline() -> Mock:
 
 
 @pytest.fixture
-def processor(mock_s3: Mock, mock_s3_control: Mock, mock_deadline: Mock) -> JobAttachmentsSweeper:
+def mock_record_handler() -> Mock:
+    """Fixture to create mock RetentionRecordHandler"""
+    return Mock()
+
+
+@pytest.fixture
+def processor(
+    mock_s3: Mock, mock_s3_control: Mock, mock_deadline: Mock, mock_record_handler: Mock
+) -> JobAttachmentsSweeper:
     """Fixture to create JobAttachmentsSweeper instance with mock clients"""
     return JobAttachmentsSweeper(
         s3_client=mock_s3,
         s3_control_client=mock_s3_control,
         deadline_client=mock_deadline,
+        retention_record_handler=mock_record_handler,
         farm_id="test-farm",
         account_id="test-account-id",
         role_arn="test-role-arn",
@@ -56,6 +67,76 @@ def test_dir(tmp_path: Path) -> Path:
 
 
 class TestJobAttachmentsSweeper:
+    def test_get_attachments_to_retain_happy_path(self, processor: JobAttachmentsSweeper):
+        """Tests retrieving attachments to retain with multiple queues and jobs."""
+        queue_job_id_map: Dict[str, List[str]] = {
+            "queue-1": ["job-1"],
+            "queue-2": ["job-2"],
+            "queue-3": ["job-3"],
+        }
+
+        mock_records: List[RetentionRecord] = [
+            RetentionRecord(queue_id="queue-1", job_id="job-1", s3_object_key="key-1"),
+            RetentionRecord(queue_id="queue-2", job_id="job-2", s3_object_key="key-2"),
+            RetentionRecord(queue_id="queue-3", job_id="job-3", s3_object_key="key-3"),
+        ]
+
+        processor.retention_record_handler.get_retention_records.return_value = mock_records
+
+        result: Set[str] = processor.get_attachments_to_retain(queue_job_id_map)
+
+        processor.retention_record_handler.get_retention_records.assert_called_once_with(
+            queue_job_id_map=queue_job_id_map
+        )
+        assert result == {"key-1", "key-2", "key-3"}
+
+    def test_get_attachments_to_retain_deduplication(self, processor: JobAttachmentsSweeper):
+        """Tests deduplication of attachment keys."""
+        queue_job_id_map: Dict[str, List[str]] = {"queue-1": ["job-1", "job-2"]}
+
+        mock_records: List[RetentionRecord] = [
+            # Both jobs have the same set of keys
+            RetentionRecord(queue_id="queue-1", job_id="job-1", s3_object_key="key-1"),
+            RetentionRecord(queue_id="queue-1", job_id="job-1", s3_object_key="key-2"),
+            RetentionRecord(queue_id="queue-1", job_id="job-2", s3_object_key="key-1"),
+            RetentionRecord(queue_id="queue-1", job_id="job-2", s3_object_key="key-2"),
+        ]
+
+        processor.retention_record_handler.get_retention_records.return_value = mock_records
+
+        result: Set[str] = processor.get_attachments_to_retain(queue_job_id_map)
+
+        assert len(result) == 2
+        assert result == {"key-1", "key-2"}
+
+    def test_get_attachments_to_retain_empty_map(self, processor: JobAttachmentsSweeper):
+        """Tests behavior with empty queue job map."""
+        queue_job_id_map: Dict[str, List[str]] = {}
+
+        processor.retention_record_handler.get_retention_records.return_value = []
+
+        result: Set[str] = processor.get_attachments_to_retain(queue_job_id_map)
+
+        processor.retention_record_handler.get_retention_records.assert_called_once_with(
+            queue_job_id_map=queue_job_id_map
+        )
+        assert result == set()
+
+    def test_get_attachments_to_retain_handler_error(self, processor: JobAttachmentsSweeper):
+        """Tests error handling when record handler fails."""
+        queue_job_id_map: Dict[str, List[str]] = {"queue-1": ["job-1"]}
+
+        error_message: str = "Failed to retrieve records"
+        processor.retention_record_handler.get_retention_records.side_effect = (
+            RetentionRecordHandlerError(error_message)
+        )
+
+        with pytest.raises(JobAttachmentsSweeperError) as err:
+            processor.get_attachments_to_retain(queue_job_id_map)
+
+        assert "Failed to get retention records" in str(err.value)
+        assert error_message in str(err.value)
+
     def test_create_tag_manifest_empty_list(self, processor: JobAttachmentsSweeper, test_dir: Path):
         """Test creating a tag manifest with an empty delete list."""
         test_file_path = test_dir / "empty_manifest.csv"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Part of the bucket sweeper project.

This PR implements a function that queries RetentionRecords and compiles a list of S3 object keys to retain for the cleanup.

### What was the solution? (How)
1. Use the RetentionRecordHandler to query for specific records matching a queue-id and job-id query map.
2. Extract the object keys from the RetentionRecords and insert them into a set.
3. Return the set of object keys to retain.

### What is the impact of this change?
Adds onto the existing bucket sweeper functionality. Deadline Cloud functionality will not be impacted -- the sweeper is an independent system.

### How was this change tested?
- Added unit tests
- Ran all unit tests
- Ran integration tests
- Manual testing with mock RetentionRecords saved to disk

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
<img width="1000" height="120" alt="Screenshot 2025-07-18 at 3 42 27 PM" src="https://github.com/user-attachments/assets/4b550277-0392-46f7-8ca0-ab979ab2b8ca" />

- Have you run the integration tests?
<img width="1000" height="106" alt="Screenshot 2025-07-18 at 3 49 15 PM" src="https://github.com/user-attachments/assets/91a1f8f9-c731-4e55-9191-5f6aa3a8522f" />

- Have you made changes to the `download` or `asset_sync` modules? No
If so, then it is highly recommended that you ensure that the docker-based unit tests pass.

### Was this change documented?

- Are relevant docstrings in the code base updated? Yes
- Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change? No

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

### Does this change impact security? No

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
