### PR TITLE
feat: get job and queue ids from s3 bucket

### DIFF
--- a/src/deadline/job_attachments/bucket_sweeper/job_attachments_sweeper.py
+++ b/src/deadline/job_attachments/bucket_sweeper/job_attachments_sweeper.py
@@ -13,7 +13,6 @@ from ..exceptions import (
     JobAttachmentS3BotoCoreError,
     RetentionRecordHandlerError,
 )
-from ..models import FarmQueuePair, FarmQueueJobTriple
 from ..job_attachments_s3_bucket_lister import JobAttachmentsS3BucketLister
 
 from deadline.job_attachments.models import RetentionRecord
@@ -69,20 +68,19 @@ class JobAttachmentsSweeper:
         self.bucket_name = bucket_name
         self.root_prefix = root_prefix
 
-    def get_queue_farm_pairs_from_s3(self) -> List[FarmQueuePair]:
+    def get_queues_in_farms_from_s3(self) -> Dict[str, List[str]]:
         """
-        Retrieves farms and their queues from S3 bucket as a list of FarmQueuePairs.
+        Retrieves farms and their queues from S3 bucket as a dictionary mapping farm_id to queue_ids.
 
         Returns:
-            List[FarmQueuePair]: A list of FarmQueuePair named tuples.
+            Dict[str, List[str]]: A dictionary mapping farm_id to a list of queue_ids.
             Example:
-                [
-                    FarmQueuePair(farm_id='farm-123', queue_id='queue-1'),
-                    FarmQueuePair(farm_id='farm-123', queue_id='queue-2'),
-                    FarmQueuePair(farm_id='farm-456', queue_id='queue-3')
-                ]
+                {
+                    'farm-123': ['queue-1', 'queue-2'],
+                    'farm-456': ['queue-3']
+                }
         """
-        farm_queue_pairs: List[FarmQueuePair] = []
+        farm_queues_map: Dict[str, List[str]] = {}
 
         base_prefix: str = f"{self.root_prefix}/Manifests"
 
@@ -93,40 +91,10 @@ class JobAttachmentsSweeper:
             queues_prefix: str = f"{base_prefix}/{farm_id}/queue"
             queue_ids: List[str] = self._get_ids_from_common_prefixes(prefix=queues_prefix)
 
-            farm_queue_pairs.extend(FarmQueuePair(farm_id, queue_id) for queue_id in queue_ids)
+            if queue_ids:
+                farm_queues_map[farm_id] = queue_ids
 
-        return farm_queue_pairs
-
-    def get_farm_queue_job_triples_from_s3(
-        self, farm_queue_pairs: List[FarmQueuePair]
-    ) -> List[FarmQueueJobTriple]:
-        """
-        Retrieves jobs for given FarmQueuePairs from S3 bucket.
-
-        Args:
-            farm_queue_pairs (List[FarmQueuePair]): List of FarmQueuePair named tuples to get jobs for
-
-        Returns:
-            List[FarmQueueJobTriple]: A list of FarmQueueJobTriple named tuples.
-            Example:
-                [
-                    FarmQueueJobTriple(farm_id='farm-123', queue_id='queue-1', job_id='job-1'),
-                    FarmQueueJobTriple(farm_id='farm-123', queue_id='queue-1', job_id='job-2'),
-                    FarmQueueJobTriple(farm_id='farm-456', queue_id='queue-3', job_id='job-4')
-                ]
-        """
-        base_prefix: str = f"{self.root_prefix}/Manifests"
-        farm_queue_job_triples: List[FarmQueueJobTriple] = []
-
-        for farm_id, queue_id in farm_queue_pairs:
-            jobs_prefix: str = f"{base_prefix}/{farm_id}/{queue_id}/job"
-            job_ids: List[str] = self._get_ids_from_common_prefixes(prefix=jobs_prefix)
-
-            farm_queue_job_triples.extend(
-                FarmQueueJobTriple(farm_id, queue_id, job_id) for job_id in job_ids
-            )
-
-        return farm_queue_job_triples
+        return farm_queues_map
 
     def _get_ids_from_common_prefixes(self, prefix: str) -> List[str]:
         """

--- a/src/deadline/job_attachments/bucket_sweeper/job_attachments_sweeper.py
+++ b/src/deadline/job_attachments/bucket_sweeper/job_attachments_sweeper.py
@@ -13,6 +13,7 @@ from ..exceptions import (
     JobAttachmentS3BotoCoreError,
     RetentionRecordHandlerError,
 )
+from ..models import FarmQueuePair, FarmQueueJobTriple
 from ..job_attachments_s3_bucket_lister import JobAttachmentsS3BucketLister
 
 from deadline.job_attachments.models import RetentionRecord
@@ -31,10 +32,10 @@ class JobAttachmentsSweeper:
         deadline_client: BaseClient,
         retention_record_handler: RetentionRecordHandlerInterface,
         job_attachments_s3_bucket_lister: JobAttachmentsS3BucketLister,
-        farm_id: str,
         account_id: str,
         role_arn: str,
         bucket_name: str,
+        root_prefix: str,
     ):
         """
         Initializes the JobAttachmentsSweeper.
@@ -49,7 +50,6 @@ class JobAttachmentsSweeper:
             s3_control_client: AWS S3 Control client for batch operations
             deadline_client: Client for interacting with Deadline
             job_attachments_s3_bucket_lister: Component to list job attachments from an S3 bucket
-            farm_id (str): The target farm_id to cleanup
             account_id (str): AWS account ID for the batch operation
             role_arn (str): The ARN of the IAM role for executing batch jobs.
                 Required permissions:
@@ -57,16 +57,119 @@ class JobAttachmentsSweeper:
                     - s3:PutObjectTagging
                     - s3:CreateJob
             bucket_name (str): target S3 bucket to cleanup
+            root_prefix (str): S3 job attachments root prefix to cleanup
         """
         self.s3 = s3_client
         self.s3_control = s3_control_client
         self.deadline = deadline_client
         self.retention_record_handler = retention_record_handler
         self.job_attachments_s3_bucket_lister = job_attachments_s3_bucket_lister
-        self.farm_id = farm_id
         self.account_id = account_id
         self.role_arn = role_arn
         self.bucket_name = bucket_name
+        self.root_prefix = root_prefix
+
+    def get_queue_farm_pairs_from_s3(self) -> List[FarmQueuePair]:
+        """
+        Retrieves farms and their queues from S3 bucket as a list of FarmQueuePairs.
+
+        Returns:
+            List[FarmQueuePair]: A list of FarmQueuePair named tuples.
+            Example:
+                [
+                    FarmQueuePair(farm_id='farm-123', queue_id='queue-1'),
+                    FarmQueuePair(farm_id='farm-123', queue_id='queue-2'),
+                    FarmQueuePair(farm_id='farm-456', queue_id='queue-3')
+                ]
+        """
+        farm_queue_pairs: List[FarmQueuePair] = []
+
+        base_prefix: str = f"{self.root_prefix}/Manifests"
+
+        farms_prefix: str = f"{base_prefix}/farm"
+        farm_ids: List[str] = self._get_ids_from_common_prefixes(prefix=farms_prefix)
+
+        for farm_id in farm_ids:
+            queues_prefix: str = f"{base_prefix}/{farm_id}/queue"
+            queue_ids: List[str] = self._get_ids_from_common_prefixes(prefix=queues_prefix)
+
+            farm_queue_pairs.extend(FarmQueuePair(farm_id, queue_id) for queue_id in queue_ids)
+
+        return farm_queue_pairs
+
+    def get_farm_queue_job_triples_from_s3(
+        self, farm_queue_pairs: List[FarmQueuePair]
+    ) -> List[FarmQueueJobTriple]:
+        """
+        Retrieves jobs for given FarmQueuePairs from S3 bucket.
+
+        Args:
+            farm_queue_pairs (List[FarmQueuePair]): List of FarmQueuePair named tuples to get jobs for
+
+        Returns:
+            List[FarmQueueJobTriple]: A list of FarmQueueJobTriple named tuples.
+            Example:
+                [
+                    FarmQueueJobTriple(farm_id='farm-123', queue_id='queue-1', job_id='job-1'),
+                    FarmQueueJobTriple(farm_id='farm-123', queue_id='queue-1', job_id='job-2'),
+                    FarmQueueJobTriple(farm_id='farm-456', queue_id='queue-3', job_id='job-4')
+                ]
+        """
+        base_prefix: str = f"{self.root_prefix}/Manifests"
+        farm_queue_job_triples: List[FarmQueueJobTriple] = []
+
+        for farm_id, queue_id in farm_queue_pairs:
+            jobs_prefix: str = f"{base_prefix}/{farm_id}/{queue_id}/job"
+            job_ids: List[str] = self._get_ids_from_common_prefixes(prefix=jobs_prefix)
+
+            farm_queue_job_triples.extend(
+                FarmQueueJobTriple(farm_id, queue_id, job_id) for job_id in job_ids
+            )
+
+        return farm_queue_job_triples
+
+    def _get_ids_from_common_prefixes(self, prefix: str) -> List[str]:
+        """
+        Extracts IDs from S3 common prefixes based on a given prefix path.
+
+        Args:
+            prefix (str): The S3 prefix path to search for IDs.
+
+        Returns:
+            List[str]: A list of extracted IDs from the common prefixes.
+
+        Raises:
+            JobAttachmentsSweeperError: If there is an error listing common prefixes
+                from the S3 bucket.
+
+        Notes:
+            - Assumes IDs are located in the second-to-last position when splitting
+            the prefix path by '/'.
+            - Skips prefixes that don't have at least 2 parts when split.
+        """
+        ids: List[str] = []
+
+        try:
+            for (
+                common_prefix_data
+            ) in self.job_attachments_s3_bucket_lister.list_common_prefixes_with_delimeter(
+                prefix=prefix
+            ):
+                common_prefix: str = common_prefix_data.get("Prefix", "")
+                split_common_prefix: List[str] = common_prefix.split("/")
+
+                if len(split_common_prefix) < 2:
+                    continue
+
+                # Prefix ends with  "/", last element will be an empty string
+                id: str = split_common_prefix[-2]
+                ids.append(id)
+        except JobAttachmentsS3BucketListerError as err:
+            raise JobAttachmentsSweeperError(
+                message=f"Failed to list common prefixes: {str(err)}"
+            ) from err
+
+        return ids
 
     def get_attachments_to_retain(self, queue_job_id_map: Dict[str, List[str]]) -> Set[str]:
         """

--- a/src/deadline/job_attachments/job_attachments_s3_bucket_lister.py
+++ b/src/deadline/job_attachments/job_attachments_s3_bucket_lister.py
@@ -19,6 +19,31 @@ class JobAttachmentsS3BucketLister(ABC):
     """Interface for listing job attachments from S3."""
 
     @abstractmethod
+    def list_common_prefixes_with_delimeter(self, prefix: str) -> Iterator[str]:
+        """
+        Lists all common prefixes within the given S3 prefix.
+
+        For example, if your S3 structure is:
+        queue-1/job-1/...
+        queue-1/job-1/...
+        queue-1/job-2/...
+
+        Then calling with prefix="queue-1/" will yield:
+        - queue-1/job-1/
+        - queue-1/job-2/
+
+        Args:
+            prefix (str): The S3 prefix to list from
+
+        Returns:
+            Iterator[str]: Stream of common prefixes found
+
+        Raises:
+            JobAttachmentsS3BucketListerError: If S3 listing fails
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def list_job_attachments(self, prefix: str) -> Iterator[S3ObjectData]:
         """
         Lists S3 objects under the given prefix.
@@ -64,6 +89,42 @@ class S3PaginationLister(JobAttachmentsS3BucketLister):
         """
         self.boto3_session = boto3_session
         self.settings = settings
+
+    def list_common_prefixes_with_delimeter(self, prefix: str) -> Iterator[str]:
+        """
+        Lists all common prefixes within the given S3 prefix.
+
+        For example, if your S3 structure is:
+        queue-1/job-1/...
+        queue-1/job-1/...
+        queue-1/job-2/...
+
+        Then calling with prefix="queue-1/" will yield:
+        - queue-1/job-1/
+        - queue-1/job-2/
+
+        Args:
+            prefix (str): The S3 prefix to list from
+
+        Returns:
+            Iterator[str]: Stream of common prefixes found
+
+        Raises:
+            JobAttachmentsS3BucketListerError: If S3 listing fails
+        """
+        s3: BaseClient = get_s3_client(session=self.boto3_session)
+        paginator: Paginator = s3.get_paginator("list_objects_v2")
+
+        try:
+            for page in paginator.paginate(
+                Bucket=self.settings.s3BucketName, Prefix=prefix, Delimiter="/"
+            ):
+                for object in page.get("CommonPrefixes", []):
+                    yield object
+        except ClientError as err:
+            raise JobAttachmentsS3BucketListerError(
+                f"Failed to list job attachments from S3: {str(err)}"
+            ) from err
 
     def list_job_attachments(
         self,
@@ -131,6 +192,21 @@ class S3InventoryLister(JobAttachmentsS3BucketLister):
         https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-inventory.html
 
     """
+
+    def list_common_prefixes_with_delimeter(self, prefix) -> Iterator[str]:
+        """
+        Lists all common prefixes within the given S3 prefix from an S3 Inventory manifest.
+
+        Args:
+            prefix (str): The S3 prefix to list from
+
+        Returns:
+            Iterator[str]: Stream of common prefixes found
+
+        Raises:
+            JobAttachmentsS3BucketListerError: If S3 listing fails
+        """
+        return super().list_common_prefixes_with_delimeter(prefix)
 
     def list_job_attachments(self, prefix: str) -> Iterator[S3ObjectData]:
         """

--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -524,13 +524,6 @@ class S3ObjectData(NamedTuple):
     etag: str
 
 
-class FarmQueuePair(NamedTuple):
-    """Represents a farm_id and queue_id pair"""
-
-    farm_id: str
-    queue_id: str
-
-
 class FarmQueueJobTriple(NamedTuple):
     """Represents a farm_id, queue_id, job_id triple"""
 

--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -522,3 +522,18 @@ class S3ObjectData(NamedTuple):
     size: int
     last_modified: datetime
     etag: str
+
+
+class FarmQueuePair(NamedTuple):
+    """Represents a farm_id and queue_id pair"""
+
+    farm_id: str
+    queue_id: str
+
+
+class FarmQueueJobTriple(NamedTuple):
+    """Represents a farm_id, queue_id, job_id triple"""
+
+    farm_id: str
+    queue_id: str
+    job_id: str

--- a/test/unit/deadline_job_attachments/bucket_sweeper/test_job_attachments_sweeper.py
+++ b/test/unit/deadline_job_attachments/bucket_sweeper/test_job_attachments_sweeper.py
@@ -10,7 +10,10 @@ from pathlib import Path
 from botocore.exceptions import BotoCoreError
 from unittest.mock import Mock
 
-from deadline.job_attachments.models import RetentionRecord, FarmQueueJobTriple, FarmQueuePair, S3ObjectData
+from deadline.job_attachments.models import (
+    RetentionRecord,
+    S3ObjectData,
+)
 from deadline.job_attachments.bucket_sweeper.job_attachments_sweeper import JobAttachmentsSweeper
 from deadline.job_attachments.exceptions import (
     JobAttachmentsS3BucketListerError,
@@ -151,9 +154,10 @@ class TestJobAttachmentsSweeper:
 
         assert "Failed to get retention records" in str(err.value)
         assert error_message in str(err.value)
-    def test_get_queue_farm_pairs_from_s3_happy_path(self, processor: JobAttachmentsSweeper):
-        """Test successfully retrieving 3 FarmQueuePairs."""
-        mock_get_ids = Mock()
+
+    def test_get_queues_in_farms_from_s3_happy_path(self, processor: JobAttachmentsSweeper):
+        """Test successfully retrieving queues for multiple farms."""
+        mock_get_ids: Mock = Mock()
         mock_get_ids.side_effect = [
             ["farm-123", "farm-456"],  # First call for farm IDs
             ["queue-1", "queue-2"],  # Second call for farm-123 queues
@@ -162,18 +166,17 @@ class TestJobAttachmentsSweeper:
 
         processor._get_ids_from_common_prefixes = mock_get_ids
 
-        result = processor.get_queue_farm_pairs_from_s3()
+        result: Dict[str, List[str]] = processor.get_queues_in_farms_from_s3()
 
-        expected = [
-            FarmQueuePair(farm_id="farm-123", queue_id="queue-1"),
-            FarmQueuePair(farm_id="farm-123", queue_id="queue-2"),
-            FarmQueuePair(farm_id="farm-456", queue_id="queue-3"),
-        ]
+        expected: Dict[str, List[str]] = {
+            "farm-123": ["queue-1", "queue-2"],
+            "farm-456": ["queue-3"],
+        }
 
-        assert len(result) == 3
+        assert len(result) == 2
         assert result == expected
 
-    def test_get_queue_farm_pairs_from_s3_no_queues(self, processor: JobAttachmentsSweeper):
+    def test_get_queues_in_farms_from_s3_no_queues(self, processor: JobAttachmentsSweeper):
         """Test when there are no queue_ids returned by _get_ids_from_common_prefixes."""
         mock_get_ids: Mock = Mock()
         mock_get_ids.side_effect = [
@@ -184,77 +187,10 @@ class TestJobAttachmentsSweeper:
 
         processor._get_ids_from_common_prefixes = mock_get_ids
 
-        result: List[FarmQueuePair] = processor.get_queue_farm_pairs_from_s3()
+        result: Dict[str, List[str]] = processor.get_queues_in_farms_from_s3()
 
         assert len(result) == 0
-        assert result == []
-
-    def test_get_farm_queue_job_triples_from_s3_happy_path(self, processor: JobAttachmentsSweeper):
-        """Test successfully retrieving FarmQueueJobTriples."""
-        mock_get_ids: Mock = Mock()
-        mock_get_ids.side_effect = [
-            ["job-1", "job-2"],  # Jobs for farm-123/queue-1
-            ["job-3"],  # Jobs for farm-123/queue-2
-            ["job-4", "job-5"],  # Jobs for farm-456/queue-3
-        ]
-
-        processor._get_ids_from_common_prefixes = mock_get_ids
-
-        farm_queue_pairs: List[FarmQueuePair] = [
-            FarmQueuePair(farm_id="farm-123", queue_id="queue-1"),
-            FarmQueuePair(farm_id="farm-123", queue_id="queue-2"),
-            FarmQueuePair(farm_id="farm-456", queue_id="queue-3"),
-        ]
-
-        result: List[FarmQueueJobTriple] = processor.get_farm_queue_job_triples_from_s3(
-            farm_queue_pairs
-        )
-
-        expected: List[FarmQueueJobTriple] = [
-            FarmQueueJobTriple(farm_id="farm-123", queue_id="queue-1", job_id="job-1"),
-            FarmQueueJobTriple(farm_id="farm-123", queue_id="queue-1", job_id="job-2"),
-            FarmQueueJobTriple(farm_id="farm-123", queue_id="queue-2", job_id="job-3"),
-            FarmQueueJobTriple(farm_id="farm-456", queue_id="queue-3", job_id="job-4"),
-            FarmQueueJobTriple(farm_id="farm-456", queue_id="queue-3", job_id="job-5"),
-        ]
-
-        assert len(result) == 5
-        assert result == expected
-
-    def test_get_farm_queue_job_triples_from_s3_no_jobs(self, processor: JobAttachmentsSweeper):
-        """Test when there are no jobs returned by _get_ids_from_common_prefixes."""
-        mock_get_ids: Mock = Mock()
-        mock_get_ids.side_effect = [
-            [],  # No jobs for farm-123/queue-1
-            [],  # No jobs for farm-123/queue-2
-            [],  # No jobs for farm-456/queue-3
-        ]
-
-        processor._get_ids_from_common_prefixes = mock_get_ids
-
-        farm_queue_pairs: List[FarmQueuePair] = [
-            FarmQueuePair(farm_id="farm-123", queue_id="queue-1"),
-            FarmQueuePair(farm_id="farm-123", queue_id="queue-2"),
-            FarmQueuePair(farm_id="farm-456", queue_id="queue-3"),
-        ]
-
-        result: List[FarmQueueJobTriple] = processor.get_farm_queue_job_triples_from_s3(
-            farm_queue_pairs
-        )
-
-        assert len(result) == 0
-        assert result == []
-
-    def test_get_farm_queue_job_triples_from_s3_empty_input(self, processor: JobAttachmentsSweeper):
-        """Test when an empty list of farm_queue_pairs is provided."""
-        mock_get_ids: Mock = Mock()
-        processor._get_ids_from_common_prefixes = mock_get_ids
-
-        result: List[FarmQueueJobTriple] = processor.get_farm_queue_job_triples_from_s3([])
-
-        assert len(result) == 0
-        assert result == []
-        mock_get_ids.assert_not_called()
+        assert result == {}
 
     def test_get_ids_from_common_prefixes_happy_path(self, processor: JobAttachmentsSweeper):
         """Test successfully getting IDs from common prefixes."""

--- a/test/unit/deadline_job_attachments/bucket_sweeper/test_job_attachments_sweeper.py
+++ b/test/unit/deadline_job_attachments/bucket_sweeper/test_job_attachments_sweeper.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from botocore.exceptions import BotoCoreError
 from unittest.mock import Mock
 
-from deadline.job_attachments.models import RetentionRecord, S3ObjectData
+from deadline.job_attachments.models import RetentionRecord, FarmQueueJobTriple, FarmQueuePair, S3ObjectData
 from deadline.job_attachments.bucket_sweeper.job_attachments_sweeper import JobAttachmentsSweeper
 from deadline.job_attachments.exceptions import (
     JobAttachmentsS3BucketListerError,
@@ -65,10 +65,10 @@ def processor(
         deadline_client=mock_deadline,
         retention_record_handler=mock_record_handler,
         job_attachments_s3_bucket_lister=mock_lister,
-        farm_id="test-farm",
         account_id="test-account-id",
         role_arn="test-role-arn",
         bucket_name="test-bucket",
+        root_prefix="test-prefix",
     )
 
 
@@ -151,6 +151,148 @@ class TestJobAttachmentsSweeper:
 
         assert "Failed to get retention records" in str(err.value)
         assert error_message in str(err.value)
+    def test_get_queue_farm_pairs_from_s3_happy_path(self, processor: JobAttachmentsSweeper):
+        """Test successfully retrieving 3 FarmQueuePairs."""
+        mock_get_ids = Mock()
+        mock_get_ids.side_effect = [
+            ["farm-123", "farm-456"],  # First call for farm IDs
+            ["queue-1", "queue-2"],  # Second call for farm-123 queues
+            ["queue-3"],  # Third call for farm-456 queues
+        ]
+
+        processor._get_ids_from_common_prefixes = mock_get_ids
+
+        result = processor.get_queue_farm_pairs_from_s3()
+
+        expected = [
+            FarmQueuePair(farm_id="farm-123", queue_id="queue-1"),
+            FarmQueuePair(farm_id="farm-123", queue_id="queue-2"),
+            FarmQueuePair(farm_id="farm-456", queue_id="queue-3"),
+        ]
+
+        assert len(result) == 3
+        assert result == expected
+
+    def test_get_queue_farm_pairs_from_s3_no_queues(self, processor: JobAttachmentsSweeper):
+        """Test when there are no queue_ids returned by _get_ids_from_common_prefixes."""
+        mock_get_ids: Mock = Mock()
+        mock_get_ids.side_effect = [
+            ["farm-123", "farm-456"],  # First call for farm IDs
+            [],  # Second call for farm-123 queues
+            [],  # Third call for farm-456 queues
+        ]
+
+        processor._get_ids_from_common_prefixes = mock_get_ids
+
+        result: List[FarmQueuePair] = processor.get_queue_farm_pairs_from_s3()
+
+        assert len(result) == 0
+        assert result == []
+
+    def test_get_farm_queue_job_triples_from_s3_happy_path(self, processor: JobAttachmentsSweeper):
+        """Test successfully retrieving FarmQueueJobTriples."""
+        mock_get_ids: Mock = Mock()
+        mock_get_ids.side_effect = [
+            ["job-1", "job-2"],  # Jobs for farm-123/queue-1
+            ["job-3"],  # Jobs for farm-123/queue-2
+            ["job-4", "job-5"],  # Jobs for farm-456/queue-3
+        ]
+
+        processor._get_ids_from_common_prefixes = mock_get_ids
+
+        farm_queue_pairs: List[FarmQueuePair] = [
+            FarmQueuePair(farm_id="farm-123", queue_id="queue-1"),
+            FarmQueuePair(farm_id="farm-123", queue_id="queue-2"),
+            FarmQueuePair(farm_id="farm-456", queue_id="queue-3"),
+        ]
+
+        result: List[FarmQueueJobTriple] = processor.get_farm_queue_job_triples_from_s3(
+            farm_queue_pairs
+        )
+
+        expected: List[FarmQueueJobTriple] = [
+            FarmQueueJobTriple(farm_id="farm-123", queue_id="queue-1", job_id="job-1"),
+            FarmQueueJobTriple(farm_id="farm-123", queue_id="queue-1", job_id="job-2"),
+            FarmQueueJobTriple(farm_id="farm-123", queue_id="queue-2", job_id="job-3"),
+            FarmQueueJobTriple(farm_id="farm-456", queue_id="queue-3", job_id="job-4"),
+            FarmQueueJobTriple(farm_id="farm-456", queue_id="queue-3", job_id="job-5"),
+        ]
+
+        assert len(result) == 5
+        assert result == expected
+
+    def test_get_farm_queue_job_triples_from_s3_no_jobs(self, processor: JobAttachmentsSweeper):
+        """Test when there are no jobs returned by _get_ids_from_common_prefixes."""
+        mock_get_ids: Mock = Mock()
+        mock_get_ids.side_effect = [
+            [],  # No jobs for farm-123/queue-1
+            [],  # No jobs for farm-123/queue-2
+            [],  # No jobs for farm-456/queue-3
+        ]
+
+        processor._get_ids_from_common_prefixes = mock_get_ids
+
+        farm_queue_pairs: List[FarmQueuePair] = [
+            FarmQueuePair(farm_id="farm-123", queue_id="queue-1"),
+            FarmQueuePair(farm_id="farm-123", queue_id="queue-2"),
+            FarmQueuePair(farm_id="farm-456", queue_id="queue-3"),
+        ]
+
+        result: List[FarmQueueJobTriple] = processor.get_farm_queue_job_triples_from_s3(
+            farm_queue_pairs
+        )
+
+        assert len(result) == 0
+        assert result == []
+
+    def test_get_farm_queue_job_triples_from_s3_empty_input(self, processor: JobAttachmentsSweeper):
+        """Test when an empty list of farm_queue_pairs is provided."""
+        mock_get_ids: Mock = Mock()
+        processor._get_ids_from_common_prefixes = mock_get_ids
+
+        result: List[FarmQueueJobTriple] = processor.get_farm_queue_job_triples_from_s3([])
+
+        assert len(result) == 0
+        assert result == []
+        mock_get_ids.assert_not_called()
+
+    def test_get_ids_from_common_prefixes_happy_path(self, processor: JobAttachmentsSweeper):
+        """Test successfully getting IDs from common prefixes."""
+        mock_prefixes = [{"Prefix": "test/123/"}, {"Prefix": "test/456/"}, {"Prefix": "test/789/"}]
+        processor.job_attachments_s3_bucket_lister.list_common_prefixes_with_delimeter.return_value = mock_prefixes
+
+        result = processor._get_ids_from_common_prefixes("test/")
+
+        assert result == ["123", "456", "789"]
+        processor.job_attachments_s3_bucket_lister.list_common_prefixes_with_delimeter.assert_called_once_with(
+            prefix="test/"
+        )
+
+    def test_get_ids_from_common_prefixes_none_exist(self, processor: JobAttachmentsSweeper):
+        """Test getting IDs when no prefixes exist."""
+        processor.job_attachments_s3_bucket_lister.list_common_prefixes_with_delimeter.return_value = []
+
+        result = processor._get_ids_from_common_prefixes("test/")
+
+        assert result == []
+        processor.job_attachments_s3_bucket_lister.list_common_prefixes_with_delimeter.assert_called_once_with(
+            prefix="test/"
+        )
+
+    def test_get_ids_from_common_prefixes_lister_error(self, processor: JobAttachmentsSweeper):
+        """Test getting IDs when lister throws an error."""
+        error_message = "Failed to list common prefixes"
+        processor.job_attachments_s3_bucket_lister.list_common_prefixes_with_delimeter.side_effect = JobAttachmentsS3BucketListerError(
+            error_message
+        )
+
+        with pytest.raises(JobAttachmentsSweeperError) as err:
+            processor._get_ids_from_common_prefixes("test/")
+
+        assert error_message in str(err.value)
+        processor.job_attachments_s3_bucket_lister.list_common_prefixes_with_delimeter.assert_called_once_with(
+            prefix="test/"
+        )
 
     def test_get_attachments_to_delete_filter_with_datetime(self, processor: JobAttachmentsSweeper):
         """Test when s3_keys_to_retain is empty - should return all objects modified after retention_datetime."""

--- a/test/unit/deadline_job_attachments/job_attachment_s3_bucket_lister/test_s3_pagination_lister.py
+++ b/test/unit/deadline_job_attachments/job_attachment_s3_bucket_lister/test_s3_pagination_lister.py
@@ -34,6 +34,66 @@ class TestS3PaginationLister:
         client.get_paginator.return_value = mock_paginator
         return client
 
+    def test_list_common_prefixes_with_delimeter_happy_path(
+        self,
+        mock_session: Mock,
+        settings: JobAttachmentS3Settings,
+        mock_s3_client: Mock,
+        mock_paginator: Mock,
+    ):
+        """Test listing common prefixes with successful response"""
+        mock_session.client.return_value = mock_s3_client
+
+        mock_paginator.paginate.return_value = [
+            {
+                "CommonPrefixes": [
+                    {"Prefix": "queue-1/job-1/"},
+                    {"Prefix": "queue-1/job-2/"},
+                    {"Prefix": "queue-1/job-3/"},
+                ]
+            }
+        ]
+
+        lister: S3PaginationLister = S3PaginationLister(mock_session, settings)
+        results = list(lister.list_common_prefixes_with_delimeter("queue-1/"))
+
+        assert len(results) == 3
+        assert results == [
+            {"Prefix": "queue-1/job-1/"},
+            {"Prefix": "queue-1/job-2/"},
+            {"Prefix": "queue-1/job-3/"},
+        ]
+
+        mock_paginator.paginate.assert_called_once_with(
+            Bucket="test-bucket", Prefix="queue-1/", Delimiter="/"
+        )
+
+    def test_list_common_prefixes_with_delimeter_client_error(
+        self,
+        mock_session: Mock,
+        settings: JobAttachmentS3Settings,
+        mock_s3_client: Mock,
+        mock_paginator: Mock,
+    ):
+        """Test handling of ClientError when listing common prefixes"""
+        mock_session.client.return_value = mock_s3_client
+
+        mock_paginator.paginate.side_effect = ClientError(
+            error_response={"Error": {"Code": "IOError", "Message": "Failed to read from S3"}},
+            operation_name="ListObjectsV2",
+        )
+
+        lister: S3PaginationLister = S3PaginationLister(mock_session, settings)
+
+        with pytest.raises(JobAttachmentsS3BucketListerError) as err:
+            list(lister.list_common_prefixes_with_delimeter("queue-1/"))
+
+        assert "Failed to list job attachments from S3" in str(err.value)
+
+        mock_paginator.paginate.assert_called_once_with(
+            Bucket="test-bucket", Prefix="queue-1/", Delimiter="/"
+        )
+
     def test_list_job_attachments_basic_listing(
         self,
         mock_session: Mock,
@@ -196,6 +256,7 @@ class TestS3PaginationLister:
 
         assert len(results) == 0
 
+
     def test_list_job_attachments_with_prefixes_happy_path(
         self,
         mock_session: Mock,
@@ -264,3 +325,4 @@ class TestS3PaginationLister:
         lister.list_job_attachments.assert_any_call(prefix="DeadlineCloud/prefix1/")
         lister.list_job_attachments.assert_any_call(prefix="DeadlineCloud/prefix2/")
         lister.list_job_attachments.assert_any_call(prefix="DeadlineCloud/prefix3/")
+

--- a/test/unit/deadline_job_attachments/job_attachment_s3_bucket_lister/test_s3_pagination_lister.py
+++ b/test/unit/deadline_job_attachments/job_attachment_s3_bucket_lister/test_s3_pagination_lister.py
@@ -256,7 +256,6 @@ class TestS3PaginationLister:
 
         assert len(results) == 0
 
-
     def test_list_job_attachments_with_prefixes_happy_path(
         self,
         mock_session: Mock,
@@ -325,4 +324,3 @@ class TestS3PaginationLister:
         lister.list_job_attachments.assert_any_call(prefix="DeadlineCloud/prefix1/")
         lister.list_job_attachments.assert_any_call(prefix="DeadlineCloud/prefix2/")
         lister.list_job_attachments.assert_any_call(prefix="DeadlineCloud/prefix3/")
-


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
As part of the bucket sweeper project, we need to identify jobs with attachments in S3 buckets and cross-reference these with job metadata to determine which files should be retained. This PR implements the first part: efficiently identifying which jobs have attachments in a given bucket.

### What was the solution? (How)
We leverage the structured format of manifest file keys `(root_prefix/Manifests/farm-id/queue-id/job-id/...)` to extract farm and queue IDs. The new functions efficiently traverse S3's common prefixes (virtual subdirectories) using delimiters to build a map of queues and their associated jobs.

As an example of the S3 delimited traversal, if your S3 structure is:
```
queue-1/job-1/...
queue-1/job-1/...
queue-1/job-2/...
```

Then calling paginating the S3 bucket with `prefix="queue-1/"` will yield:
```
queue-1/job-1/
queue-1/job-2/
```

### What is the impact of this change?
No impact to core Deadline Cloud functionality. The code in this PR is completely isolated. It only interacts with existing job attachments from an S3 bucket.

### How was this change tested?
- Added unit tests
- Ran all unit tests
- Ran integration tests
- Manual testing with service account

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
<img width="1000" height="118" alt="Screenshot 2025-07-21 at 4 34 09 PM" src="https://github.com/user-attachments/assets/33e6f21c-462b-43a9-bdd6-a8413a1c162f" />

- Have you run the integration tests?
<img width="1000" height="126" alt="Screenshot 2025-07-21 at 4 40 20 PM" src="https://github.com/user-attachments/assets/84543b6f-4223-4360-a776-ea954f1544b3" />


- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.

### Was this change documented? Yes

- Are relevant docstrings in the code base updated? Yes
- Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change? No

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
