### PR TITLE
feat: ad-hoc cleanup cli command

### DIFF
--- a/src/deadline/client/cli/_groups/attachment_group.py
+++ b/src/deadline/client/cli/_groups/attachment_group.py
@@ -4,6 +4,7 @@
 All the `deadline attachment` commands:
     * upload
     * download
+    * cleanup
 """
 
 from __future__ import annotations
@@ -211,4 +212,67 @@ def attachment_upload(
         path_mapping_rules=path_mapping_rules,
         upload_manifest_path=upload_manifest_path,
         logger=logger,
+    )
+
+
+@cli_attachment.command(
+    name="cleanup",
+    help="BETA - Cleanup all unused files in a job attachments S3 bucket.",
+)
+@click.option(
+    "--bucket-name",
+    help="Name of the S3 bucket where cleanup will be performed (e.g., 'my-attachment-bucket')",
+)
+@click.option(
+    "--root-prefix",
+    help="Base folder path within the S3 bucket to start cleanup from (e.g., 'DeadlineCloud')",
+)
+@click.option(
+    "--retention-days",
+    help="Number of days to keep files. Files accessed within this many days will be preserved, older unused files will be deleted (e.g., 30)",
+)
+@click.option(
+    "--role-arn",
+    required=False,
+    help="Role ARN for executing S3 batch operations tagging job",
+)
+@click.option(
+    "--dry-run",
+    default=False,
+    is_flag=True,
+    help="Creates a delete objects manifest but does not create a batch job.",
+)
+@click.option("--json", default=False, is_flag=True, help="Output is printed as JSON for scripting")
+@_handle_error
+def cleanup(
+    bucket_name: str,
+    root_prefix: str,
+    role_arn: str,
+    dry_run: bool,
+    json: bool,
+    retention_days: int = 120,
+    **args,
+):
+    """
+    Cleanup all unused files in a job attachments S3 bucket.
+    """
+    config = _apply_cli_options_to_config(**args)
+    logger: ClickLogger = ClickLogger(is_json=json)
+
+    retention_days: int = int(retention_days)
+    boto3_session: boto3.Session = api.get_boto3_session(config=config)
+
+    if not role_arn:
+        role_arn: str = config_file.get_setting("defaults.s3_batch_job_role_arn", config=config)
+    else:
+        config_file.set_setting("defaults.s3_batch_job_role_arn", role_arn, config=config)
+
+    attachment_api._attachment_sweep(
+        bucket_name=bucket_name,
+        root_prefix=root_prefix,
+        boto3_session=boto3_session,
+        s3_batch_job_arn_role=role_arn,
+        retention_days=retention_days,
+        dry_run=dry_run,
+        logging_function_callback=logger.echo,
     )

--- a/src/deadline/client/config/config_file.py
+++ b/src/deadline/client/config/config_file.py
@@ -122,6 +122,10 @@ SETTINGS: Dict[str, Dict[str, Any]] = {
         "depend": "defaults.farm_id",
         "description": "The file system mode to use for job attachments when running jobs. COPIED means to download a copy of the attachment data, VIRTUAL means to use a virtual file system for lazy loading.",
     },
+    "defaults.s3_batch_job_role_arn": {
+        "default": "",
+        "description": "The role arn passed to the S3 batch job operations to tag job attachments for deletion. Used for the bucket sweeper.",
+    },
     "settings.s3_max_pool_connections": {
         "default": "50",
         "description": (

--- a/src/deadline/job_attachments/api/__init__.py
+++ b/src/deadline/job_attachments/api/__init__.py
@@ -3,6 +3,7 @@
 __all__ = [
     "attachment_download",
     "attachment_upload",
+    "_attachment_sweep",
     "summarize_paths_by_nested_directory",
     "summarize_paths_by_sequence",
     "human_readable_file_size",
@@ -10,7 +11,7 @@ __all__ = [
     "PathSummary",
 ]
 
-from .attachment import attachment_download, attachment_upload
+from .attachment import attachment_download, attachment_upload, _attachment_sweep
 from ...common.path_utils import (
     human_readable_file_size,
     summarize_paths_by_nested_directory,

--- a/src/deadline/job_attachments/api/attachment.py
+++ b/src/deadline/job_attachments/api/attachment.py
@@ -4,9 +4,10 @@ import os
 import boto3
 import json
 
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Callable
 from pathlib import Path
 from dataclasses import asdict
+from datetime import datetime, timezone, timedelta
 
 from deadline.job_attachments.api._utils import _read_manifests
 from deadline.job_attachments.asset_manifests.base_manifest import BaseAssetManifest
@@ -17,6 +18,17 @@ from deadline.job_attachments.models import (
     UploadManifestInfo,
     PathMappingRule,
 )
+from deadline.job_attachments.bucket_sweeper.bucket_sweeper_components import (
+    _initialize_dependencies,
+    _collect_farm_queue_job_triples,
+    _process_manifests_and_create_retention_records,
+    _determine_objects_to_delete,
+    _create_deletion_batch_job,
+    SweeperDependencies,
+)
+from deadline.job_attachments.bucket_sweeper.job_attachments_sweeper import JobAttachmentsSweeper
+from deadline.job_attachments.bucket_sweeper.retention_record_handler import RetentionRecordHandler
+from deadline.job_attachments.models import FarmQueueJobTriple
 from deadline.job_attachments.progress_tracker import DownloadSummaryStatistics
 from deadline.job_attachments.upload import S3AssetUploader
 from deadline.client.cli._groups.click_logger import ClickLogger
@@ -275,3 +287,116 @@ def _process_path_mapping(
     )
 
     return path_mapping_rule_list
+
+
+def _attachment_sweep(
+    bucket_name: str,
+    root_prefix: str,
+    boto3_session: boto3.Session,
+    s3_batch_job_arn_role: str,
+    retention_days: int = 120,
+    dry_run: bool = False,
+    logging_function_callback: Callable[[str], None] = lambda msg: None,
+) -> None:
+    """
+    Orchestrates the cleanup of job attachments in an S3 bucket based on job last run dates.
+
+    This method performs a cleanup process that:
+        1. Identifies active jobs and their associated attachments
+        2. Creates retention records for files that should be preserved
+        3. Determines which files can be safely deleted based on age and usage
+        4. Generates a batch job manifest for S3 deletion operations
+
+    Args:
+        bucket_name: Name of the S3 bucket containing job attachments
+        root_prefix: S3 prefix path where job attachments are stored
+        boto3_session: authenticated boto3 session
+        s3_batch_job_arn_role: arn role for S3 batch tagging operation
+        retention_days: Number of days to retain files. Files last used before
+                    (today - retention_days) will be deleted. Must be between 0 and 120.
+                    Defaults to 120.
+        dry_run: flag to create S3 batch operations job
+        logging_function_callback: signature for logging function
+
+    Retention Logic:
+        Files are retained based on date-level comparison:
+        - Files last used on or after the retention date (today - retention_days) are kept
+        - Files last used before the retention date are deleted
+        - Timestamps are truncated to midnight UTC, so only calendar dates matter
+
+    Note:
+        All date comparisons use UTC timezone to match S3 and Deadline API responses.
+    """
+    if not all([bucket_name, root_prefix, boto3_session, s3_batch_job_arn_role, retention_days]):
+        raise NonValidInputError(
+            "Missing parameters: bucket-name, root-prefix, and retention-days, boto3_session, and s3_batch_job_arn_role parameters are required"
+        )
+
+    if retention_days < 0 or retention_days > 120:
+        raise NonValidInputError("retention_days must be within 0 and 120 days")
+
+    working_directory: Path = Path("/tmp") / "bucket_sweeper"
+    working_directory.mkdir(exist_ok=True)
+
+    logging_function_callback(
+        f"Starting bucket sweep for bucket and root prefix: {bucket_name}/{root_prefix}"
+    )
+
+    # All comparisons done in UTC - dates returned by S3 and Deadline APIs are in UTC
+    today: datetime = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    retention_datetime: datetime = today - timedelta(days=retention_days)
+
+    logging_function_callback(f"Retaining all files last used on or after: {retention_datetime}")
+
+    # Initialize services
+    components: SweeperDependencies = _initialize_dependencies(
+        working_directory=working_directory,
+        bucket_name=bucket_name,
+        root_prefix=root_prefix,
+        boto3_session=boto3_session,
+        role_arn=s3_batch_job_arn_role,
+    )
+    sweeper: JobAttachmentsSweeper = components.sweeper
+    job_attachment_s3_settings: JobAttachmentS3Settings = components.job_attachment_s3_settings
+    retention_record_handler: RetentionRecordHandler = components.retention_record_handler
+
+    # Get farms, queues, jobs, and convert into triples
+    farm_queue_job_triples: List[FarmQueueJobTriple] = _collect_farm_queue_job_triples(
+        sweeper=sweeper, boto3_session=boto3_session, retention_datetime=retention_datetime
+    )
+
+    logging_function_callback(f"Found {len(farm_queue_job_triples)} active jobs.")
+
+    # Download manifests, extract asset hashes, and create retention records
+    _process_manifests_and_create_retention_records(
+        farm_queue_job_triples=farm_queue_job_triples,
+        boto3_session=boto3_session,
+        job_attachment_s3_settings=job_attachment_s3_settings,
+        working_directory=working_directory,
+        retention_record_handler=retention_record_handler,
+    )
+
+    # Compare retention set to s3 bucket to create a delete list
+    delete_list: List[str] = _determine_objects_to_delete(
+        farm_queue_job_triples=farm_queue_job_triples,
+        sweeper=sweeper,
+        retention_datetime=retention_datetime,
+        root_prefix=root_prefix,
+    )
+
+    logging_function_callback(f"Found {len(delete_list)} files to delete.")
+
+    _create_deletion_batch_job(
+        delete_list=delete_list,
+        sweeper=sweeper,
+        working_directory=working_directory,
+        root_prefix=root_prefix,
+        dry_run=dry_run,
+    )
+
+    if not dry_run:
+        logging_function_callback("Created S3 batch job to handle deletion.")
+    else:
+        logging_function_callback("Dry run: Delete manifest created but objects not deleted.")
+
+    logging_function_callback("Completed bucket sweep.")

--- a/src/deadline/job_attachments/bucket_sweeper/bucket_sweeper_components.py
+++ b/src/deadline/job_attachments/bucket_sweeper/bucket_sweeper_components.py
@@ -1,0 +1,299 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import boto3
+
+from pathlib import Path
+from typing import Dict, List, NamedTuple, Set
+from datetime import datetime
+from botocore.client import BaseClient
+
+from .retention_record_handler import RetentionRecordHandler
+from .job_attachments_sweeper import JobAttachmentsSweeper
+from ..job_attachments_s3_bucket_lister import S3PaginationLister
+from ..models import (
+    AssetHash,
+    FarmQueueJobTriple,
+    JobAttachmentS3Settings,
+    RetentionRecord,
+)
+from ..manifest_handling import (
+    _get_all_manifest_s3_keys_for_job,
+    _load_manifests_from_disk,
+    _extract_asset_hashes_from_manifests,
+)
+from ..manifest_download import _download_job_manifests_using_s3_keys
+from ..asset_manifests.base_manifest import BaseAssetManifest
+
+from deadline.client.api._list_active_job_ids import _list_active_job_ids
+
+
+class SweeperDependencies(NamedTuple):
+    """Tuple to enforce components returned by the initialization function"""
+
+    sweeper: JobAttachmentsSweeper
+    job_attachment_s3_settings: JobAttachmentS3Settings
+    retention_record_handler: RetentionRecordHandler
+
+
+def _initialize_dependencies(
+    working_directory: Path,
+    bucket_name: str,
+    root_prefix: str,
+    boto3_session: boto3.Session,
+    role_arn: str,
+) -> SweeperDependencies:
+    """
+    Initialize all required services and components for the bucket sweeper.
+
+    Args:
+        working_directory: Directory path where temporary files (like manifests)
+            will be managed during sweeper operations.
+        bucket_name: Name of the S3 bucket containing job attachments to be swept.
+        root_prefix: S3 key prefix that defines the root path for job attachments
+            within the bucket.
+        boto3_session: boto3 session
+        role_arn: s3 batch operations batch tagging role arn
+
+    Returns:
+        SweeperComponents: Container object with initialized boto3 session, sweeper
+            instance, S3 settings, and retention record handler ready for use.
+    """
+    job_attachment_s3_settings: JobAttachmentS3Settings = JobAttachmentS3Settings(
+        s3BucketName=bucket_name,
+        rootPrefix=root_prefix,
+    )
+
+    # Initialize AWS clients
+    s3_client: BaseClient = boto3_session.client("s3")
+    s3_control_client: BaseClient = boto3_session.client("s3control")
+    deadline_client: BaseClient = boto3_session.client("deadline")
+
+    # Initialize handlers and job attachments lister
+    retention_record_handler: RetentionRecordHandler = RetentionRecordHandler(
+        storage_file_path=working_directory / "storage_file.json"
+    )
+
+    job_attachments_object_fetcher: S3PaginationLister = S3PaginationLister(
+        boto3_session=boto3_session, settings=job_attachment_s3_settings
+    )
+
+    sweeper: JobAttachmentsSweeper = JobAttachmentsSweeper(
+        s3_client=s3_client,
+        s3_control_client=s3_control_client,
+        deadline_client=deadline_client,
+        retention_record_handler=retention_record_handler,
+        job_attachments_s3_bucket_lister=job_attachments_object_fetcher,
+        boto3_session=boto3_session,
+        role_arn=role_arn,
+        bucket_name=bucket_name,
+        root_prefix=root_prefix,
+    )
+
+    return SweeperDependencies(
+        sweeper=sweeper,
+        job_attachment_s3_settings=job_attachment_s3_settings,
+        retention_record_handler=retention_record_handler,
+    )
+
+
+def _collect_farm_queue_job_triples(
+    sweeper: JobAttachmentsSweeper,
+    boto3_session: boto3.Session,
+    retention_datetime: datetime,
+) -> List[FarmQueueJobTriple]:
+    """
+    Collect all farm-queue-job triples that need to be processed for retention.
+
+    This method retrieves all farms and their associated queues from S3, then for each
+    farm-queue combination, it finds jobs that have ended before the retention datetime.
+    The resulting triples represent the scope of job attachments that must be retained.
+
+    Important Note:
+        Jobs without an endedAt date are handled separately during the delete list
+        compilation phase by checking their last_modified_date.
+
+    Args:
+        sweeper: The JobAttachmentsSweeper instance used to retrieve farm-queue mappings
+        boto3_session: AWS session for making API calls to list jobs
+        retention_datetime: Jobs that ended before this datetime are candidates for cleanup, ones
+            that ended after or at this datetime will be retained
+
+    Returns:
+        List of FarmQueueJobTriple objects, each representing a farm-queue-job combination
+        that needs to be processed to retain its associated assets. Only includes jobs that have
+        an endedAt date after or at the retention datetime.
+    """
+    farm_queues_map: Dict[str, List[str]] = sweeper.get_queues_in_farms_from_s3()
+
+    farm_queue_job_triples: List[FarmQueueJobTriple] = []
+
+    for farm_id, queue_ids in farm_queues_map.items():
+        # Only returns jobs that have an endedAt date. Checking last_modified_date when
+        # compiling a delete list handles cases for jobs that have no endedAt date.
+        queue_job_id_map: Dict[str, List[str]] = _list_active_job_ids(
+            boto3_session=boto3_session,
+            farm_id=farm_id,
+            queue_ids=queue_ids,
+            retention_datetime=retention_datetime,
+        )
+
+        for queue_id, job_ids in queue_job_id_map.items():
+            farm_queue_job_triples.extend(
+                FarmQueueJobTriple(farm_id=farm_id, queue_id=queue_id, job_id=job_id)
+                for job_id in job_ids
+            )
+
+    return farm_queue_job_triples
+
+
+def _process_manifests_and_create_retention_records(
+    farm_queue_job_triples: List[FarmQueueJobTriple],
+    boto3_session: boto3.Session,
+    job_attachment_s3_settings: JobAttachmentS3Settings,
+    working_directory: Path,
+    retention_record_handler: RetentionRecordHandler,
+) -> None:
+    """
+    Process job attachment manifests and create retention records for S3 objects.
+
+    This method orchestrates the complete workflow for processing job attachments:
+        1. Downloads manifest files from S3 for each specified job
+        2. Extracts asset information from the manifests
+        3. Generates S3 object keys for both manifests and assets
+        4. Creates retention records to keep track of objects that need to be preserved
+
+    Args:
+        farm_queue_job_triples: List of (farm_id, queue_id, job_id) tuples identifying
+            the jobs to process.
+        boto3_session: AWS session for S3 operations.
+        job_attachment_s3_settings: S3 configuration settings for job attachments,
+            including bucket name and key prefixes.
+        working_directory: Local directory path where manifest files will be downloaded
+            and organized by farm/queue/job hierarchy.
+        retention_record_handler: Handler for inserting retention records into storage.
+
+    Raises:
+        S3 operation errors if manifest download fails.
+        File system errors if local directory creation fails.
+        Validation errors if manifest parsing fails.
+    """
+    download_directory: Path = working_directory / "manifests"
+    download_directory.mkdir(exist_ok=True)
+
+    for farm_id, queue_id, job_id in farm_queue_job_triples:
+        job_specific_directory: Path = download_directory / farm_id / queue_id / job_id
+        job_specific_directory.mkdir(parents=True, exist_ok=True)
+
+        # Download manifests
+        manifest_keys: List[str] = _get_all_manifest_s3_keys_for_job(
+            session=boto3_session,
+            job_attachment_settings=job_attachment_s3_settings,
+            farm_id=farm_id,
+            queue_id=queue_id,
+            job_id=job_id,
+        )
+        _download_job_manifests_using_s3_keys(
+            session=boto3_session,
+            manifest_keys=manifest_keys,
+            job_attachment_settings=job_attachment_s3_settings,
+            download_directory=job_specific_directory,
+        )
+
+        # Get asset s3 keys
+        manifests: List[BaseAssetManifest] = _load_manifests_from_disk(
+            manifests_directory=job_specific_directory
+        )
+        asset_hashes: List[AssetHash] = _extract_asset_hashes_from_manifests(manifests=manifests)
+        asset_s3_keys: List[str] = [
+            f"{job_attachment_s3_settings.rootPrefix}/Data/{asset.hash}.{asset.hash_alg.value}"
+            for asset in asset_hashes
+        ]
+
+        # Save retention records
+        retain_object_keys: List[str] = manifest_keys + asset_s3_keys
+        retention_records: List[RetentionRecord] = [
+            RetentionRecord(queue_id=queue_id, job_id=job_id, s3_object_key=key)
+            for key in retain_object_keys
+        ]
+        retention_record_handler.insert_retention_records(records=retention_records)
+
+
+def _determine_objects_to_delete(
+    farm_queue_job_triples: List[FarmQueueJobTriple],
+    sweeper: JobAttachmentsSweeper,
+    retention_datetime: datetime,
+    root_prefix: str,
+) -> List[str]:
+    """
+    Determine which S3 objects should be deleted based on S3 last modified date and
+    a object retention list.
+
+    This method analyzes job attachments to identify objects that are safe to delete
+    by first determining which objects must be retained (based on active jobs), then
+    identifying all other objects as candidates for deletion.
+
+    Args:
+        farm_queue_job_triples: List of (farm_id, queue_id, job_id) tuples representing
+            the jobs to consider for retention analysis.
+        sweeper: The JobAttachmentsSweeper instance used to query S3 and determine
+            retention and deletion candidates.
+        retention_datetime: The cutoff datetime - objects modified before this time
+            may be eligible for deletion if not otherwise retained.
+        root_prefix: The S3 key prefix to limit the scope of the deletion analysis.
+
+    Returns:
+        List of S3 object keys that have not been used since the retention_datetime and
+        are thereby safe to delete.
+    """
+    # Create queue-job mapping
+    queue_job_id_map: Dict[str, List[str]] = {}
+    for _, queue_id, job_id in farm_queue_job_triples:
+        if queue_id not in queue_job_id_map:
+            queue_job_id_map[queue_id] = []
+        queue_job_id_map[queue_id].append(job_id)
+
+    # Get retention set
+    retention_set: Set[str] = sweeper.get_attachments_to_retain(queue_job_id_map=queue_job_id_map)
+
+    # Get delete list
+    delete_list: List[str] = sweeper.get_attachments_to_delete(
+        s3_keys_to_retain=retention_set,
+        retention_datetime=retention_datetime,
+        root_prefix=root_prefix,
+    )
+
+    return delete_list
+
+
+def _create_deletion_batch_job(
+    delete_list: List[str],
+    sweeper: JobAttachmentsSweeper,
+    working_directory: Path,
+    root_prefix: str,
+    dry_run: bool,
+) -> None:
+    """
+    Orchestrates S3 batch operations job creation.
+
+    This method orchestrates the creation of a batch deletion job by:
+        1. Creating a CSV manifest file containing the list of S3 objects to delete
+        2. Uploading the manifest to S3 for use by the batch job
+        3. Creating the S3 batch operations job
+
+    Args:
+        delete_list: List of S3 object keys to be deleted
+        sweeper: JobAttachmentsSweeper instance used for manifest operations
+        working_directory: Local directory path where temporary files are created
+        root_prefix: S3 key prefix used for organizing uploaded manifest files
+        dry_run: flag for creating s3 batch job
+    """
+    # Create CSV for batch deletion
+    tag_manifest_path: Path = working_directory / "delete_objects_manifest.csv"
+    sweeper._create_tag_manifest(file_path=tag_manifest_path, delete_list=delete_list)
+
+    tag_manifest_s3_key: str = f"{root_prefix}/delete_objects_manifest.csv"
+    sweeper._upload_tag_manifest(manifest_path=tag_manifest_path, object_key=tag_manifest_s3_key)
+
+    # Create batch job
+    if not dry_run:
+        sweeper._create_batch_tag_s3_job(s3_manifest_key=tag_manifest_s3_key)

--- a/src/deadline/job_attachments/bucket_sweeper/job_attachments_sweeper.py
+++ b/src/deadline/job_attachments/bucket_sweeper/job_attachments_sweeper.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import csv
+import boto3
 
 from datetime import datetime
 from typing import List, Dict, Any, Set
@@ -31,7 +32,7 @@ class JobAttachmentsSweeper:
         deadline_client: BaseClient,
         retention_record_handler: RetentionRecordHandlerInterface,
         job_attachments_s3_bucket_lister: JobAttachmentsS3BucketLister,
-        account_id: str,
+        boto3_session: boto3.Session,
         role_arn: str,
         bucket_name: str,
         root_prefix: str,
@@ -49,7 +50,7 @@ class JobAttachmentsSweeper:
             s3_control_client: AWS S3 Control client for batch operations
             deadline_client: Client for interacting with Deadline
             job_attachments_s3_bucket_lister: Component to list job attachments from an S3 bucket
-            account_id (str): AWS account ID for the batch operation
+            boto3_session: boto3 session
             role_arn (str): The ARN of the IAM role for executing batch jobs.
                 Required permissions:
                     - s3:GetObject
@@ -63,7 +64,7 @@ class JobAttachmentsSweeper:
         self.deadline = deadline_client
         self.retention_record_handler = retention_record_handler
         self.job_attachments_s3_bucket_lister = job_attachments_s3_bucket_lister
-        self.account_id = account_id
+        self.boto3_session = boto3_session
         self.role_arn = role_arn
         self.bucket_name = bucket_name
         self.root_prefix = root_prefix
@@ -344,8 +345,10 @@ class JobAttachmentsSweeper:
             The CLI client requires s3:CreateJob and iam:PassRole permissions to create a batch tagging job.
         """
         try:
+            account_id: str = self.boto3_session.client("sts").get_caller_identity()["Account"]
+
             self.s3_control.create_job(
-                AccountId=self.account_id,
+                AccountId=account_id,
                 RoleArn=self.role_arn,
                 Operation=operation,
                 Manifest=manifest,

--- a/src/deadline/job_attachments/bucket_sweeper/retention_record_handler.py
+++ b/src/deadline/job_attachments/bucket_sweeper/retention_record_handler.py
@@ -75,15 +75,13 @@ class RetentionRecordHandler(RetentionRecordHandlerInterface):
 
         Creates the storage file with an empty JSON object.
 
+        Note:
+            Overwrites any existing storage file.
+
         Raises:
-            RetentionRecordHandlerError: If storage file already exists or it cannot be created
+            RetentionRecordHandlerError: If storage file cannot be created
                 (e.g., due to permissions, disk space, or invalid path).
         """
-        if self.storage_file_path.exists():
-            raise RetentionRecordHandlerError(
-                "Failed to initialize handler, storage file already exists"
-            )
-
         try:
             content: QueueJobKeyMapping = {"queues": {}}
             self.storage_file_path.write_text(json.dumps(content))

--- a/src/deadline/job_attachments/manifest_handling.py
+++ b/src/deadline/job_attachments/manifest_handling.py
@@ -25,6 +25,10 @@ def _get_all_manifest_s3_keys_for_job(
     """
     Retrieves all manifest (both input and output) S3 keys for a specific job.
 
+    Note:
+        Ignores errors for missing manifests in S3 - not all jobs may have manifests
+            e.g if a job instantly fails
+
     Args:
         session: boto3 Session for AWS credentials
         job_attachment_settings: S3 job attachments settings
@@ -41,8 +45,11 @@ def _get_all_manifest_s3_keys_for_job(
     root_prefix: str = job_attachment_settings.rootPrefix.rstrip("/")
     output_manifest_prefix: str = f"{root_prefix}/Manifests/{farm_id}/{queue_id}/{job_id}/"
 
+    input_manifest_keys: List[str] = []
+    output_manifest_keys: List[str] = []
+
     try:
-        input_manifest_keys: List[str] = _get_input_manifest_keys_for_job(
+        input_manifest_keys = _get_input_manifest_keys_for_job(
             session=session,
             s3_root_prefix=job_attachment_settings.rootPrefix,
             farm_id=farm_id,
@@ -50,11 +57,17 @@ def _get_all_manifest_s3_keys_for_job(
             job_id=job_id,
         )
         # TODO: Implement fetching output manifests with JobAttachmentsLister
-        output_manifest_keys: List[str] = _get_tasks_manifests_keys_from_s3(
+        # TODO: current implementation stops retrieving output manifests after returning
+        #       not found job attachments error... need to fix we should continue looking for manifests
+        output_manifest_keys = _get_tasks_manifests_keys_from_s3(
             manifest_prefix=output_manifest_prefix,
             s3_bucket=job_attachment_settings.s3BucketName,
             session=session,
         )
+    except JobAttachmentsError as err:
+        # Ignore error if manifest cannot be found
+        if "Unable to find asset manifest in s3" not in str(err):
+            raise err
     except Exception as err:
         raise JobAttachmentsError(f"Failed to get all job manifest keys: {str(err)}") from err
 

--- a/test/integ/deadline_job_attachments/test_bucket_sweeper_components.py
+++ b/test/integ/deadline_job_attachments/test_bucket_sweeper_components.py
@@ -1,0 +1,183 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import pytest
+
+from typing import List
+from unittest.mock import MagicMock, patch
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+from deadline.job_attachments.bucket_sweeper.bucket_sweeper_components import (
+    SweeperDependencies,
+    _initialize_dependencies,
+    _collect_farm_queue_job_triples,
+    _process_manifests_and_create_retention_records,
+    _determine_objects_to_delete,
+    _create_deletion_batch_job,
+)
+from deadline.job_attachments.bucket_sweeper.job_attachments_sweeper import JobAttachmentsSweeper
+from deadline.job_attachments.models import FarmQueueJobTriple
+
+
+@pytest.fixture
+def mock_boto3_session() -> MagicMock:
+    session: MagicMock = MagicMock()
+    session.client.side_effect = lambda service_name: MagicMock()
+    return session
+
+
+@pytest.fixture
+def mock_get_session() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_sweeper() -> MagicMock:
+    return MagicMock(spec=JobAttachmentsSweeper)
+
+
+@pytest.fixture
+def mock_retention_handler() -> MagicMock:
+    return MagicMock()
+
+
+def test_initialize_services(
+    mock_get_session: MagicMock, mock_boto3_session: MagicMock, tmp_path: Path
+):
+    """Test that dependencies are initialized successfully."""
+    working_dir: Path = tmp_path / "test_sweeper"
+    working_dir.mkdir(exist_ok=True)
+
+    components: SweeperDependencies = _initialize_dependencies(
+        working_directory=working_dir,
+        bucket_name="test-bucket",
+        root_prefix="test-prefix",
+        boto3_session=mock_boto3_session,
+        role_arn="test-role-arn",
+    )
+
+    assert isinstance(components, SweeperDependencies)
+    mock_boto3_session.client.assert_any_call("s3")
+    mock_boto3_session.client.assert_any_call("s3control")
+    mock_boto3_session.client.assert_any_call("deadline")
+
+
+def test_collect_farm_queue_job_triples(mock_sweeper: MagicMock, mock_boto3_session: MagicMock):
+    """Test collection of farm-queue-job triples from S3 and Deadline service."""
+    mock_sweeper.get_queues_in_farms_from_s3.return_value = {
+        "farm-1": ["queue-1", "queue-2"],
+        "farm-2": ["queue-3"],
+    }
+
+    # Mock the _list_active_job_ids function
+    with patch(
+        "deadline.job_attachments.bucket_sweeper.bucket_sweeper_components._list_active_job_ids"
+    ) as mock_list_jobs:
+        mock_list_jobs.side_effect = lambda **kwargs: {
+            "queue-1": ["job-1", "job-2"] if kwargs["farm_id"] == "farm-1" else [],
+            "queue-2": ["job-3"] if kwargs["farm_id"] == "farm-1" else [],
+            "queue-3": ["job-4", "job-5"] if kwargs["farm_id"] == "farm-2" else [],
+        }
+
+        # Random retention date to execute the call
+        retention_date: datetime = datetime.now(timezone.utc) - timedelta(days=30)
+        result: List[FarmQueueJobTriple] = _collect_farm_queue_job_triples(
+            mock_sweeper, mock_boto3_session, retention_date
+        )
+
+        assert FarmQueueJobTriple("farm-1", "queue-1", "job-2") in result
+        assert FarmQueueJobTriple("farm-1", "queue-2", "job-3") in result
+        assert FarmQueueJobTriple("farm-2", "queue-3", "job-4") in result
+        assert FarmQueueJobTriple("farm-2", "queue-3", "job-5") in result
+
+
+def test_process_manifests_and_create_retention_records(
+    mock_boto3_session: MagicMock,
+    mock_retention_handler: MagicMock,
+    tmp_path: Path,
+):
+    """Test processing job manifests and creating retention records for asset tracking."""
+    farm_queue_job_triples: List[FarmQueueJobTriple] = [
+        FarmQueueJobTriple("farm-1", "queue-1", "job-1")
+    ]
+
+    job_attachment_settings: MagicMock = MagicMock()
+
+    # Mock the manifest handling functions
+    with patch(
+        "deadline.job_attachments.bucket_sweeper.bucket_sweeper_components._get_all_manifest_s3_keys_for_job"
+    ) as mock_get_keys, patch(
+        "deadline.job_attachments.bucket_sweeper.bucket_sweeper_components._download_job_manifests_using_s3_keys"
+    ) as mock_download, patch(
+        "deadline.job_attachments.bucket_sweeper.bucket_sweeper_components._load_manifests_from_disk"
+    ) as mock_load, patch(
+        "deadline.job_attachments.bucket_sweeper.bucket_sweeper_components._extract_asset_hashes_from_manifests"
+    ) as mock_extract:
+        mock_get_keys.return_value = ["manifest-key-1", "manifest-key-2"]
+        mock_load.return_value = [MagicMock()]
+        mock_extract.return_value = [
+            MagicMock(hash="hash1", hash_alg=MagicMock(value="xxh128")),
+            MagicMock(hash="hash2", hash_alg=MagicMock(value="xxh128")),
+        ]
+
+        _process_manifests_and_create_retention_records(
+            farm_queue_job_triples=farm_queue_job_triples,
+            boto3_session=mock_boto3_session,
+            job_attachment_s3_settings=job_attachment_settings,
+            working_directory=tmp_path,
+            retention_record_handler=mock_retention_handler,
+        )
+
+        mock_get_keys.assert_called_once()
+        mock_download.assert_called_once()
+        mock_load.assert_called_once()
+        mock_extract.assert_called_once()
+
+        # Check that retention records were created
+        mock_retention_handler.insert_retention_records.assert_called_once()
+        records = mock_retention_handler.insert_retention_records.call_args[1]["records"]
+        assert len(records) == 4  # 2 manifest keys + 2 asset keys
+
+
+def test_determine_objects_to_delete(mock_sweeper: MagicMock):
+    """Test identification of S3 objects eligible for deletion based on retention policy."""
+    farm_queue_job_triples: List[FarmQueueJobTriple] = [
+        FarmQueueJobTriple("farm-1", "queue-1", "job-1"),
+        FarmQueueJobTriple("farm-1", "queue-1", "job-2"),
+    ]
+
+    mock_sweeper.get_attachments_to_retain.return_value = {"key1", "key2", "key3"}
+    mock_sweeper.get_attachments_to_delete.return_value = ["key4", "key5"]
+
+    retention_date: datetime = datetime.now(timezone.utc) - timedelta(days=30)
+    result: List[str] = _determine_objects_to_delete(
+        farm_queue_job_triples=farm_queue_job_triples,
+        sweeper=mock_sweeper,
+        retention_datetime=retention_date,
+        root_prefix="test-prefix",
+    )
+
+    assert result == ["key4", "key5"]
+    mock_sweeper.get_attachments_to_retain.assert_called_once()
+    mock_sweeper.get_attachments_to_delete.assert_called_once_with(
+        s3_keys_to_retain={"key1", "key2", "key3"},
+        retention_datetime=retention_date,
+        root_prefix="test-prefix",
+    )
+
+
+def test_create_and_upload_batch_job(mock_sweeper, tmp_path):
+    """Test creation and upload of S3 batch job for object deletion."""
+    delete_list = ["key1", "key2", "key3"]
+
+    _create_deletion_batch_job(
+        delete_list=delete_list,
+        sweeper=mock_sweeper,
+        working_directory=tmp_path,
+        root_prefix="test-prefix",
+        dry_run=False,
+    )
+
+    mock_sweeper._create_tag_manifest.assert_called_once()
+    mock_sweeper._upload_tag_manifest.assert_called_once()
+    mock_sweeper._create_batch_tag_s3_job.assert_called_once()

--- a/test/integ/deadline_job_attachments/test_job_attachments.py
+++ b/test/integ/deadline_job_attachments/test_job_attachments.py
@@ -20,6 +20,7 @@ from deadline_test_fixtures.job_attachment_manager import JobAttachmentManager
 from pytest import LogCaptureFixture, TempPathFactory
 
 from deadline.job_attachments import asset_sync, download, upload
+from deadline.job_attachments.api import _attachment_sweep
 from deadline.job_attachments.asset_manifests import (
     ManifestVersion,
     HashAlgorithm,
@@ -1606,3 +1607,109 @@ def test_download_outputs_windows_long_file_path(
         )
     finally:
         shutil.rmtree(WINDOWS_UNC_PATH_STRING_PREFIX + long_root_path)
+
+
+def _setup_create_job(
+    upload_input_files_one_asset_in_cas: UploadInputFilesOneAssetInCasOutputs,
+    job_template: str,
+    job_attachment_test: JobAttachmentTest,
+) -> str:
+    """
+    Create a job with the provided template and wait for the job to be created.
+    """
+    farm_id: str = job_attachment_test.farm_id
+    queue_id: str = job_attachment_test.queue_id
+
+    # Setup failure for the test.
+    assert farm_id
+    assert queue_id
+
+    # Create a job w/ CAS data already created.
+    job_response = job_attachment_test.deadline_client.create_job(
+        farmId=farm_id,
+        queueId=queue_id,
+        attachments=upload_input_files_one_asset_in_cas.attachments.to_dict(),  # type: ignore
+        targetTaskRunStatus="SUSPENDED",
+        template=job_template,
+        templateType="JSON",
+        priority=50,
+    )
+
+    job_id: str = job_response["jobId"]
+
+    # Wait for the job to be created.
+    waiter = job_attachment_test.deadline_client.get_waiter("job_create_complete")
+    waiter.wait(
+        jobId=job_id,
+        queueId=job_attachment_test.queue_id,
+        farmId=job_attachment_test.farm_id,
+    )
+
+    # Return the created Job ID.
+    return job_id
+
+
+@pytest.mark.integ
+def test_attachment_sweep(
+    upload_input_files_one_asset_in_cas: UploadInputFilesOneAssetInCasOutputs,
+    default_job_template: str,
+    job_attachment_test: JobAttachmentTest,
+):
+    """
+    Test that the attachment sweep function can identify and process job attachments for cleanup.
+        Requires: S3_BATCH_JOB_ARN_ROLE env variable
+    """
+    # TODO: Improve integration test. Need scaffolding to test that the sweeper properly identifies active
+    # jobs/files and possibly test that objects are tagged correctly.
+
+    boto3_session: boto3.Session = boto3.Session()
+
+    # Get environment variables with proper access method
+    bucket_name: str = job_attachment_test.job_attachment_resources.bucket_name
+    bucket_root_prefix: str = job_attachment_test.bucket_root_prefix
+    s3_batch_job_arn_role: str = os.getenv("S3_BATCH_JOB_ARN_ROLE", "")
+
+    # Skip test if required environment variables are not set
+    if not s3_batch_job_arn_role:
+        pytest.skip("S3_BATCH_JOB_ARN_ROLE environment variable not set")
+
+    # Verify we have the necessary test data
+    assert bucket_name
+    assert bucket_root_prefix
+
+    _setup_create_job(
+        upload_input_files_one_asset_in_cas=upload_input_files_one_asset_in_cas,
+        job_template=default_job_template,
+        job_attachment_test=job_attachment_test,
+    )
+
+    # Count objects in bucket before sweep
+    objects_before = list(
+        job_attachment_test.bucket.objects.filter(Prefix=f"{bucket_root_prefix}/")
+    )
+
+    _attachment_sweep(
+        bucket_name=bucket_name,
+        root_prefix=bucket_root_prefix,
+        boto3_session=boto3_session,
+        s3_batch_job_arn_role=s3_batch_job_arn_role,
+        retention_days=1,
+    )
+
+    # Note: The actual deletion happens via S3 batch job, so we mainly verify
+    # the sweep process completed successfully without throwing exceptions
+    csv_manifest_key: str = f"{bucket_root_prefix}/delete_objects_manifest.csv"
+    s3_client = boto3.client("s3")
+    response = s3_client.get_object(Bucket=bucket_name, Key=csv_manifest_key)
+    csv_manifest = response["Body"].read().decode("utf-8")
+
+    assert len(csv_manifest) == 0, "CSV manifest should not contain any objects to delete"
+
+    objects_after = list(job_attachment_test.bucket.objects.filter(Prefix=f"{bucket_root_prefix}/"))
+
+    # Ensure number of objects is the same after sweep (S3 lifecycle policy handles deletion afterward)
+    assert len(objects_before) > 0
+    assert len(objects_before) + 1 == len(objects_after)  # +1 accounts for delete manifest
+
+    # After creation, S3 Batch job will fail because delete_objects_manifest.csv will be
+    # torn down before batch job can access it.

--- a/test/unit/deadline_client/cli/test_cli_config.py
+++ b/test/unit/deadline_client/cli/test_cli_config.py
@@ -36,7 +36,7 @@ def test_cli_config_show_defaults(fresh_deadline_config):
     assert fresh_deadline_config in result.output
 
     # Assert the expected number of settings
-    assert len(settings.keys()) == 16
+    assert len(settings.keys()) == 17
 
     for setting_name in settings.keys():
         assert setting_name in result.output
@@ -106,6 +106,7 @@ def test_cli_config_show_modified_config(fresh_deadline_config):
     config.set_setting("settings.s3_max_pool_connections", "100")
     config.set_setting("settings.small_file_threshold_multiplier", "15")
     config.set_setting("settings.known_asset_paths", "/known/asset/path")
+    config.set_setting("defaults.s3_batch_job_role_arn", "arn::aws:iam::123:role/bucket-sweeper")
 
     runner = CliRunner()
     result = runner.invoke(main, ["config", "show"])

--- a/test/unit/deadline_job_attachments/bucket_sweeper/test_job_attachments_sweeper.py
+++ b/test/unit/deadline_job_attachments/bucket_sweeper/test_job_attachments_sweeper.py
@@ -24,6 +24,12 @@ from deadline.job_attachments.exceptions import (
 
 
 @pytest.fixture
+def mock_boto3_session() -> Mock:
+    """Fixture to create mock Boto3 Session"""
+    return Mock()
+
+
+@pytest.fixture
 def mock_s3() -> Mock:
     """Fixture to create mock AWS S3 client"""
     return Mock()
@@ -55,6 +61,7 @@ def mock_lister() -> Mock:
 
 @pytest.fixture
 def processor(
+    mock_boto3_session: Mock,
     mock_s3: Mock,
     mock_s3_control: Mock,
     mock_deadline: Mock,
@@ -68,7 +75,7 @@ def processor(
         deadline_client=mock_deadline,
         retention_record_handler=mock_record_handler,
         job_attachments_s3_bucket_lister=mock_lister,
-        account_id="test-account-id",
+        boto3_session=mock_boto3_session,
         role_arn="test-role-arn",
         bucket_name="test-bucket",
         root_prefix="test-prefix",
@@ -416,14 +423,21 @@ class TestJobAttachmentsSweeper:
             processor._submit_tagging_batch_job({}, {})
 
     def test_create_batch_tag_s3_job(
-        self, processor: JobAttachmentsSweeper, mock_s3: Mock, mock_s3_control: Mock
+        self,
+        processor: JobAttachmentsSweeper,
+        mock_boto3_session: Mock,
+        mock_s3: Mock,
+        mock_s3_control: Mock,
     ):
         """Test creating S3 batch tagging job"""
         # Test data
         s3_manifest_key: str = "test/test.csv"
 
-        # Mock S3 head_object response
+        # Mock responses
         mock_s3.head_object.return_value = {"ETag": "test-etag"}
+        mock_boto3_session.client("sts").get_caller_identity.return_value = {
+            "Account": "test-account-id"
+        }
 
         # Call method
         processor._create_batch_tag_s3_job(s3_manifest_key)

--- a/test/unit/deadline_job_attachments/bucket_sweeper/test_retention_record_handler.py
+++ b/test/unit/deadline_job_attachments/bucket_sweeper/test_retention_record_handler.py
@@ -33,15 +33,12 @@ class TestRetentionRecordHandler:
             assert json.load(file) == {"queues": {}}
 
     def test_initialize_storage_file_exists(self, handler: RetentionRecordHandler):
-        """Test initialization fails when storage file already exists"""
+        """Test initialization does NOT fail when storage file already exists"""
 
         storage_file: Path = Path(handler.storage_file_path)
         storage_file.touch()
 
-        with pytest.raises(RetentionRecordHandlerError) as err:
-            handler._initialize_storage()
-
-        assert "storage file already exists" in str(err)
+        handler._initialize_storage()
 
     def test_initialize_storage_write_fails(self, tmp_path: Path):
         """Test initialization fails when writing to file fails"""


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Part of the bucket sweeper project.

This PR adds the ad-hoc CLI command and orchestrates the cleanup.

```
deadline attachment cleanup --bucket-name --root-prefix --retention-days

bucket-name: str
root-prefix: str
retention-days: int
    where 0 <= days <= 120  # behaviour changes if days > 120
```

**Retention Logic:**

Files are retained based on a date-level comparison. With a retention period of `N` days:

- Files last used on or after the retention date `(today - N days)` are kept.
- Files last used before the retention date are deleted.

Since timestamps are truncated to midnight (00:00:00 UTC), only the calendar date matters for retention decisions.

### What was the solution? (How)
- Created a BucketSweeper class to orchestrate all cleanup functionality.
- Broke up functionality into smaller helper functions for readability and easier testing.

### What is the impact of this change?
No impact to core Deadline functionality. The sweeper only interacts with existing job attachments. The command will also NOT delete objects from a user's S3 bucket, a targeted lifecycle policy handles deletion.

### How was this change tested?
- Added integration tests
- Ran unit and integration tests
- Manual E2E tests with real S3 bucket and job attachments

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
<img width="1000" height="164" alt="Screenshot 2025-07-23 at 8 59 20 PM" src="https://github.com/user-attachments/assets/1ebfde71-e4ec-40c4-8b0a-882ed030c9b7" />

- Have you run the integration tests?
<img width="1000" height="147" alt="Screenshot 2025-07-23 at 9 05 51 PM" src="https://github.com/user-attachments/assets/e2db63b3-213c-4ad6-98ab-df3eeaaa00d5" />

- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.

### Was this change documented? Yes

- Are relevant docstrings in the code base updated? Yes
- Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change? No

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

### Does this change impact security? No

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
